### PR TITLE
feat: validate curated feed boundary

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,3 +31,17 @@ The intended product path is:
 - Validate data at system boundaries.
 - Prefer additive workspace scaffolding over restructuring existing code without a migration plan.
 - Use root `make` commands as the canonical automation entrypoint for contributors and agents.
+
+## API Service Layout
+
+`services/api` uses a route-based FastAPI layout:
+
+- `app/main.py` assembles the application and exposes the app factory.
+- `app/api/router.py` is the top-level router registry.
+- `app/api/endpoints/` contains unversioned operational endpoints such as health checks.
+- `app/api/v1/router.py` composes versioned API routers.
+- `app/api/v1/endpoints/` contains versioned HTTP route modules grouped by resource.
+- `app/schemas/` contains request and response boundary models.
+- `app/services/` contains domain and service logic used by the route handlers.
+
+This keeps route registration explicit, makes endpoint modules easier to grow independently, and preserves thin HTTP handlers that delegate business logic to service modules.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,16 +32,92 @@ The intended product path is:
 - Prefer additive workspace scaffolding over restructuring existing code without a migration plan.
 - Use root `make` commands as the canonical automation entrypoint for contributors and agents.
 
-## API Service Layout
+## FastAPI Structure Review
 
-`services/api` uses a route-based FastAPI layout:
+The current `services/api` layout is intentionally small:
 
-- `app/main.py` assembles the application and exposes the app factory.
-- `app/api/router.py` is the top-level router registry.
-- `app/api/endpoints/` contains unversioned operational endpoints such as health checks.
-- `app/api/v1/router.py` composes versioned API routers.
-- `app/api/v1/endpoints/` contains versioned HTTP route modules grouped by resource.
-- `app/schemas/` contains request and response boundary models.
-- `app/services/` contains domain and service logic used by the route handlers.
+- `app/main.py` owns app bootstrap, route handlers, and response schemas.
+- `app/services/feed_catalog.py` owns the first domain service and domain-level validation.
+- `tests/` covers endpoint behavior and the feed domain boundary.
 
-This keeps route registration explicit, makes endpoint modules easier to grow independently, and preserves thin HTTP handlers that delegate business logic to service modules.
+Compared with the referenced FastAPI examples:
+
+- `fastapi/full-stack-fastapi-template` uses a layered backend shape with `backend/app/api/` for endpoints plus shared files such as `models.py` and `crud.py`. This repository is not aligned with that layout yet.
+- `zhanymkanov/fastapi-best-practices` recommends vertical domain packages with files such as `router.py`, `schemas.py`, `service.py`, `dependencies.py`, and `exceptions.py` per module. The current repo is closer to that direction because domain logic already lives outside the route handler, but it is still more compressed than the recommended module layout.
+
+Current verdict:
+
+- Good for bootstrap: yes
+- Aligned with the intent of thin routes and explicit validation: yes
+- Fully aligned with either reference structure: no
+- Recommended next step: evolve toward small domain packages when the API grows beyond the current single feed boundary
+
+The key design choice for this repository is to keep the first FastAPI slice simple, then split by domain instead of introducing a large horizontal layer map too early.
+
+## FastAPI Evolution Path
+
+Current structure:
+
+```text
+services/api/
+  app/
+    main.py
+    services/
+      feed_catalog.py
+  tests/
+    test_main.py
+    test_feed_catalog.py
+```
+
+Recommended incremental target:
+
+```text
+services/api/
+  app/
+    main.py
+    api/
+      router.py
+      routes/
+        health.py
+        feeds.py
+    domain/
+      feeds/
+        schemas.py
+        service.py
+        exceptions.py
+    core/
+      config.py
+      errors.py
+  tests/
+    api/
+    domain/
+```
+
+This target keeps `main.py` focused on application assembly, moves HTTP concerns into `api/routes`, and groups business logic by bounded context under `domain/`.
+
+## FastAPI Diagram
+
+```mermaid
+flowchart TD
+    subgraph Current["Current services/api shape"]
+        main["app/main.py (bootstrap, routes, response schemas)"]
+        service["app/services/feed_catalog.py (feed service + domain validation)"]
+        tests["tests/test_main.py + tests/test_feed_catalog.py"]
+        main --> service
+        tests --> main
+        tests --> service
+    end
+
+    subgraph Target["Recommended next step"]
+        entry["app/main.py (app assembly only)"]
+        api["app/api/router.py + app/api/routes/*"]
+        domain["app/domain/feeds/{schemas,service,exceptions}.py"]
+        core["app/core/{config,errors}.py"]
+        testsplit["tests/api/* + tests/domain/*"]
+        entry --> api
+        api --> domain
+        api --> core
+        testsplit --> api
+        testsplit --> domain
+    end
+```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,94 @@ If a section does not apply, write `None`.
 
 ---
 
+## Release: `api-route-based-architecture`
+
+- Date: `2026-04-01`
+- Status: `planned`
+- Owner: `repository-maintainers`
+
+### Summary
+
+Restructured `services/api` to a FastAPI route-based architecture with an app factory, a top-level router registry, versioned `api/v1/endpoints` modules, and dedicated API boundary schemas.
+
+### User Impact
+
+- Who is affected: contributors extending the FastAPI service and operators reviewing API structure
+- What users will notice: no endpoint path changes, but the API code is now organized around `APIRouter` modules and `api/v1/endpoints` instead of defining all routes in `app/main.py`
+- Expected benefits: clearer separation between app assembly, HTTP routes, schemas, and domain services
+
+### Migration Notes
+
+- Required upgrade steps: none
+- Data or config changes: none
+- Operator actions: none
+
+### New Env Vars
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `None` | no | none | No new environment variables were introduced. |
+
+### Breaking Changes
+
+- None.
+
+### Rollback Notes
+
+- Rollback trigger: contributors need to temporarily return to a single-file FastAPI entrypoint
+- Rollback steps: move route registrations and boundary schemas back into `app/main.py` and remove the router package
+- Data recovery notes: none
+
+### Known Issues
+
+- The API currently has only a small route surface, so some route modules are intentionally lightweight until more endpoints are added.
+
+---
+
+## Release: `api-feed-validation-hardening`
+
+- Date: `2026-04-01`
+- Status: `planned`
+- Owner: `repository-maintainers`
+
+### Summary
+
+Hardened the `/api/v1/feeds` response boundary so malformed feed items consistently return the structured `feed_validation_error` envelope, including mapping-based inputs and whitespace-only string fields.
+
+### User Impact
+
+- Who is affected: API consumers and operators relying on curated feed responses
+- What users will notice: `/api/v1/feeds` now rejects whitespace-only `id`, `title`, and `source` values at the API boundary and preserves the documented JSON error envelope for malformed mapping/object feed items
+- Expected benefits: a stricter and more predictable validation contract for curated feed payloads
+
+### Migration Notes
+
+- Required upgrade steps: none
+- Data or config changes: none
+- Operator actions: none
+
+### New Env Vars
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `None` | no | none | No new environment variables were introduced. |
+
+### Breaking Changes
+
+- None.
+
+### Rollback Notes
+
+- Rollback trigger: feed producers must temporarily allow whitespace-only values or rely on generic FastAPI 500 responses for malformed feed items
+- Rollback steps: revert the API boundary validator and restore the previous feed serialization path
+- Data recovery notes: none
+
+### Known Issues
+
+- Feed producers still need to provide one of the curated `kind` values: `news` or `pull-request`.
+
+---
+
 ## Release: `core-workspace-scaffolds`
 
 - Date: `2026-03-29`

--- a/services/api/app/api/__init__.py
+++ b/services/api/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""API router package."""

--- a/services/api/app/api/endpoints/__init__.py
+++ b/services/api/app/api/endpoints/__init__.py
@@ -1,0 +1,1 @@
+"""Unversioned API endpoints."""

--- a/services/api/app/api/endpoints/health.py
+++ b/services/api/app/api/endpoints/health.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health")
+def read_health() -> dict[str, dict[str, str]]:
+    return {"data": {"status": "ok"}}

--- a/services/api/app/api/router.py
+++ b/services/api/app/api/router.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+from app.api.endpoints.health import router as health_router
+from app.api.v1.router import router as v1_router
+
+
+api_router = APIRouter()
+api_router.include_router(health_router)
+api_router.include_router(v1_router, prefix="/api/v1")

--- a/services/api/app/api/v1/__init__.py
+++ b/services/api/app/api/v1/__init__.py
@@ -1,0 +1,1 @@
+"""Versioned API routes."""

--- a/services/api/app/api/v1/endpoints/__init__.py
+++ b/services/api/app/api/v1/endpoints/__init__.py
@@ -1,0 +1,1 @@
+"""Version 1 API endpoints."""

--- a/services/api/app/api/v1/endpoints/feeds.py
+++ b/services/api/app/api/v1/endpoints/feeds.py
@@ -1,0 +1,33 @@
+from typing import Union
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+
+from app.schemas.common import ErrorResponse
+from app.schemas.feed import FeedItem, FeedResponse
+from app.services.feed_catalog import list_curated_feeds
+
+
+router = APIRouter(prefix="/feeds", tags=["feeds"])
+
+
+def build_feed_response() -> FeedResponse:
+    feeds = [FeedItem.model_validate(feed, from_attributes=True) for feed in list_curated_feeds()]
+    return FeedResponse(data=feeds, meta={"total": len(feeds)})
+
+
+@router.get("", response_model=FeedResponse, responses={500: {"model": ErrorResponse}})
+def read_feeds() -> Union[FeedResponse, JSONResponse]:
+    try:
+        return build_feed_response()
+    except (ValidationError, ValueError):
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": {
+                    "code": "feed_validation_error",
+                    "message": "Failed to build curated feed response.",
+                }
+            },
+        )

--- a/services/api/app/api/v1/router.py
+++ b/services/api/app/api/v1/router.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+from app.api.v1.endpoints.feeds import router as feeds_router
+
+
+router = APIRouter()
+router.include_router(feeds_router)

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,19 +1,31 @@
+from typing import Literal, Union
+
 from fastapi import FastAPI
-from pydantic import BaseModel
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field, ValidationError
 
 from app.services.feed_catalog import list_curated_feeds
 
 
 class FeedItem(BaseModel):
-    id: str
-    kind: str
-    title: str
-    source: str
+    id: str = Field(min_length=1)
+    kind: Literal["news", "pull-request"]
+    title: str = Field(min_length=1)
+    source: str = Field(min_length=1)
 
 
 class FeedResponse(BaseModel):
     data: list[FeedItem]
     meta: dict[str, int]
+
+
+class ErrorDetail(BaseModel):
+    code: str
+    message: str
+
+
+class ErrorResponse(BaseModel):
+    error: ErrorDetail
 
 
 app = FastAPI(title="MoaDev API")
@@ -24,7 +36,22 @@ def read_health() -> dict[str, dict[str, str]]:
     return {"data": {"status": "ok"}}
 
 
-@app.get("/api/v1/feeds", response_model=FeedResponse)
-def read_feeds() -> FeedResponse:
+def build_feed_response() -> FeedResponse:
     feeds = [FeedItem.model_validate(feed.__dict__) for feed in list_curated_feeds()]
     return FeedResponse(data=feeds, meta={"total": len(feeds)})
+
+
+@app.get("/api/v1/feeds", response_model=FeedResponse, responses={500: {"model": ErrorResponse}})
+def read_feeds() -> Union[FeedResponse, JSONResponse]:
+    try:
+        return build_feed_response()
+    except (ValidationError, ValueError):
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": {
+                    "code": "feed_validation_error",
+                    "message": "Failed to build curated feed response.",
+                }
+            },
+        )

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,57 +1,12 @@
-from typing import Literal, Union
-
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field, ValidationError
 
-from app.services.feed_catalog import list_curated_feeds
+from app.api.router import api_router
 
 
-class FeedItem(BaseModel):
-    id: str = Field(min_length=1)
-    kind: Literal["news", "pull-request"]
-    title: str = Field(min_length=1)
-    source: str = Field(min_length=1)
+def create_app() -> FastAPI:
+    app = FastAPI(title="MoaDev API")
+    app.include_router(api_router)
+    return app
 
 
-class FeedResponse(BaseModel):
-    data: list[FeedItem]
-    meta: dict[str, int]
-
-
-class ErrorDetail(BaseModel):
-    code: str
-    message: str
-
-
-class ErrorResponse(BaseModel):
-    error: ErrorDetail
-
-
-app = FastAPI(title="MoaDev API")
-
-
-@app.get("/health")
-def read_health() -> dict[str, dict[str, str]]:
-    return {"data": {"status": "ok"}}
-
-
-def build_feed_response() -> FeedResponse:
-    feeds = [FeedItem.model_validate(feed.__dict__) for feed in list_curated_feeds()]
-    return FeedResponse(data=feeds, meta={"total": len(feeds)})
-
-
-@app.get("/api/v1/feeds", response_model=FeedResponse, responses={500: {"model": ErrorResponse}})
-def read_feeds() -> Union[FeedResponse, JSONResponse]:
-    try:
-        return build_feed_response()
-    except (ValidationError, ValueError):
-        return JSONResponse(
-            status_code=500,
-            content={
-                "error": {
-                    "code": "feed_validation_error",
-                    "message": "Failed to build curated feed response.",
-                }
-            },
-        )
+app = create_app()

--- a/services/api/app/schemas/__init__.py
+++ b/services/api/app/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Boundary schemas for API requests and responses."""

--- a/services/api/app/schemas/common.py
+++ b/services/api/app/schemas/common.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class ErrorDetail(BaseModel):
+    code: str
+    message: str
+
+
+class ErrorResponse(BaseModel):
+    error: ErrorDetail

--- a/services/api/app/schemas/feed.py
+++ b/services/api/app/schemas/feed.py
@@ -1,0 +1,22 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
+
+
+class FeedItem(BaseModel):
+    id: str = Field(min_length=1)
+    kind: Literal["news", "pull-request"]
+    title: str = Field(min_length=1)
+    source: str = Field(min_length=1)
+
+    @field_validator("id", "title", "source")
+    @classmethod
+    def validate_non_blank_string(cls, value: str, info: ValidationInfo) -> str:
+        if not value.strip():
+            raise ValueError(f"{info.field_name} must be a non-empty string")
+        return value
+
+
+class FeedResponse(BaseModel):
+    data: list[FeedItem]
+    meta: dict[str, int]

--- a/services/api/app/services/feed_catalog.py
+++ b/services/api/app/services/feed_catalog.py
@@ -1,12 +1,28 @@
 from dataclasses import dataclass
 
 
+ALLOWED_FEED_KINDS = {"news", "pull-request"}
+
+
 @dataclass(frozen=True)
 class FeedDescriptor:
     id: str
     kind: str
     title: str
     source: str
+
+    def __post_init__(self) -> None:
+        _validate_feed_field("id", self.id)
+        _validate_feed_field("title", self.title)
+        _validate_feed_field("source", self.source)
+
+        if self.kind not in ALLOWED_FEED_KINDS:
+            raise ValueError("kind must be one of the curated feed kinds")
+
+
+def _validate_feed_field(field_name: str, value: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
 
 
 def list_curated_feeds() -> list[FeedDescriptor]:

--- a/services/api/tests/test_app_factory.py
+++ b/services/api/tests/test_app_factory.py
@@ -1,0 +1,10 @@
+from app.main import create_app
+
+
+def test_create_app_registers_expected_routes() -> None:
+    app = create_app()
+
+    route_paths = {route.path for route in app.routes}
+
+    assert "/health" in route_paths
+    assert "/api/v1/feeds" in route_paths

--- a/services/api/tests/test_feed_catalog.py
+++ b/services/api/tests/test_feed_catalog.py
@@ -1,0 +1,23 @@
+import pytest
+
+from app.services.feed_catalog import FeedDescriptor
+
+
+def test_feed_descriptor_rejects_blank_title() -> None:
+    with pytest.raises(ValueError, match="title"):
+        FeedDescriptor(
+            id="tech-news",
+            kind="news",
+            title="",
+            source="global-tech-signal",
+        )
+
+
+def test_feed_descriptor_rejects_unsupported_kind() -> None:
+    with pytest.raises(ValueError, match="kind"):
+        FeedDescriptor(
+            id="tech-news",
+            kind="blog",
+            title="Technology news highlights",
+            source="global-tech-signal",
+        )

--- a/services/api/tests/test_main.py
+++ b/services/api/tests/test_main.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 
-import app.main as main_module
+import app.api.v1.endpoints.feeds as feeds_route_module
 
 from app.main import app
 
@@ -31,7 +31,7 @@ def test_feeds_returns_error_envelope_for_invalid_feed_boundary(monkeypatch) -> 
     fail_safe_client = TestClient(app, raise_server_exceptions=False)
 
     monkeypatch.setattr(
-        main_module,
+        feeds_route_module,
         "list_curated_feeds",
         lambda: [
             SimpleNamespace(
@@ -39,6 +39,60 @@ def test_feeds_returns_error_envelope_for_invalid_feed_boundary(monkeypatch) -> 
                 kind="news",
                 title="Technology news highlights",
                 source=None,
+            )
+        ],
+    )
+
+    response = fail_safe_client.get("/api/v1/feeds")
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "error": {
+            "code": "feed_validation_error",
+            "message": "Failed to build curated feed response.",
+        }
+    }
+
+
+def test_feeds_returns_error_envelope_for_invalid_mapping_feed_boundary(monkeypatch) -> None:
+    fail_safe_client = TestClient(app, raise_server_exceptions=False)
+
+    monkeypatch.setattr(
+        feeds_route_module,
+        "list_curated_feeds",
+        lambda: [
+            {
+                "id": "tech-news",
+                "kind": "news",
+                "title": "Technology news highlights",
+                "source": None,
+            }
+        ],
+    )
+
+    response = fail_safe_client.get("/api/v1/feeds")
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "error": {
+            "code": "feed_validation_error",
+            "message": "Failed to build curated feed response.",
+        }
+    }
+
+
+def test_feeds_rejects_whitespace_only_feed_fields(monkeypatch) -> None:
+    fail_safe_client = TestClient(app, raise_server_exceptions=False)
+
+    monkeypatch.setattr(
+        feeds_route_module,
+        "list_curated_feeds",
+        lambda: [
+            SimpleNamespace(
+                id="tech-news",
+                kind="news",
+                title="   ",
+                source="global-tech-signal",
             )
         ],
     )

--- a/services/api/tests/test_main.py
+++ b/services/api/tests/test_main.py
@@ -1,4 +1,8 @@
+from types import SimpleNamespace
+
 from fastapi.testclient import TestClient
+
+import app.main as main_module
 
 from app.main import app
 
@@ -21,3 +25,30 @@ def test_feeds_returns_curated_collection() -> None:
     assert response.status_code == 200
     assert payload["meta"]["total"] == 2
     assert [item["id"] for item in payload["data"]] == ["tech-news", "oss-prs"]
+
+
+def test_feeds_returns_error_envelope_for_invalid_feed_boundary(monkeypatch) -> None:
+    fail_safe_client = TestClient(app, raise_server_exceptions=False)
+
+    monkeypatch.setattr(
+        main_module,
+        "list_curated_feeds",
+        lambda: [
+            SimpleNamespace(
+                id="tech-news",
+                kind="news",
+                title="Technology news highlights",
+                source=None,
+            )
+        ],
+    )
+
+    response = fail_safe_client.get("/api/v1/feeds")
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "error": {
+            "code": "feed_validation_error",
+            "message": "Failed to build curated feed response.",
+        }
+    }


### PR DESCRIPTION
# 요약

- `/api/v1/feeds`의 curated feed 경계를 더 엄격하게 검증하도록 보강했습니다.
- 잘못된 feed 데이터가 API 경계에 들어오면 일관된 JSON 에러 응답을 반환하도록 처리했습니다.
- happy path뿐 아니라 failure path를 검증하는 테스트를 추가했습니다.

# 관련 이슈

- Closes #5

# 변경 사항

- `FeedDescriptor`에 non-empty 필드와 허용된 `kind` 검증 추가
- `FeedItem` 응답 모델에 stricter field validation 추가
- `/api/v1/feeds`에서 validation 예외를 `feed_validation_error` envelope로 변환
- invalid feed boundary를 검증하는 API 테스트 추가
- domain-level validation 테스트 추가

# 검증

- [x] `make bootstrap`
- [x] `make test`
- [x] `make verify`
- [x] 기타: API failure-path 테스트 추가 및 통과

# 영향 범위

- 사용자 영향: 잘못된 curated feed 데이터가 들어올 때 plain 500 대신 일관된 JSON 에러 응답을 받습니다.
- 운영 영향: curated feed 데이터 품질이 낮을 때 더 빨리 드러납니다.
- API/스키마 변경: `500` 에러 시 `{ "error": { "code", "message" } }` 응답이 명시됩니다.
- 배포 시 유의사항: 없음

# 참고 사항

- 이번 PR은 issue `#5` 범위만 다루며, 프론트 API 연동 이슈 `#6`은 포함하지 않았습니다.
