### PR TITLE
feat: build editorial web home feed

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,401 @@
+:root {
+  --page-background: #eef2f9;
+  --page-background-strong: #dfe8fb;
+  --surface: rgba(255, 255, 255, 0.78);
+  --surface-strong: rgba(255, 255, 255, 0.94);
+  --line: rgba(15, 23, 42, 0.1);
+  --line-strong: rgba(15, 23, 42, 0.18);
+  --text-primary: #10203b;
+  --text-secondary: #54627a;
+  --accent: #0a67ff;
+  --accent-soft: rgba(10, 103, 255, 0.12);
+  --success: #0f8d69;
+  --warning: #b7670f;
+  --shadow-lg: 0 30px 80px rgba(27, 45, 94, 0.12);
+  --shadow-md: 0 16px 40px rgba(27, 45, 94, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+  background:
+    radial-gradient(circle at top left, rgba(168, 208, 255, 0.55), transparent 34%),
+    radial-gradient(circle at top right, rgba(255, 237, 194, 0.7), transparent 30%),
+    linear-gradient(180deg, #f7f9fd 0%, var(--page-background) 55%, #edf3fa 100%);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text-primary);
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.home-page {
+  width: min(1200px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 32px 0 72px;
+}
+
+.masthead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 44px;
+}
+
+.masthead__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.masthead__brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #16396f 0%, #0a67ff 100%);
+  color: #fff;
+  box-shadow: var(--shadow-md);
+}
+
+.masthead__meta {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.9fr);
+  gap: 24px;
+  margin-bottom: 26px;
+}
+
+.hero__copy,
+.hero__panel,
+.section-strip__item,
+.feature-story,
+.story-card,
+.briefing-card,
+.signal-card {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow-md);
+}
+
+.hero__copy {
+  position: relative;
+  overflow: hidden;
+  padding: 40px;
+  border-radius: 34px;
+}
+
+.hero__copy::after {
+  content: "";
+  position: absolute;
+  inset: auto -40px -70px auto;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(10, 103, 255, 0.18) 0%, rgba(10, 103, 255, 0) 72%);
+}
+
+.eyebrow,
+.card-eyebrow,
+.section-strip__id,
+.briefing-card__eyebrow,
+.signal-card__eyebrow {
+  margin: 0 0 12px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hero__title,
+.feature-story__title,
+.hero__panel h2 {
+  margin: 0;
+  font-family: Georgia, "Iowan Old Style", "Times New Roman", serif;
+  letter-spacing: -0.03em;
+}
+
+.hero__title {
+  max-width: 11ch;
+  font-size: clamp(3rem, 7vw, 5.4rem);
+  line-height: 0.95;
+}
+
+.hero__summary,
+.hero__panel p,
+.section-strip__item p,
+.story-card p,
+.briefing-card p,
+.briefing-card li,
+.signal-card p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.hero__summary {
+  max-width: 58ch;
+  margin: 18px 0 26px;
+  font-size: 1.08rem;
+}
+
+.hero__status-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 10px 14px;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.status-pill--live {
+  background: rgba(15, 141, 105, 0.12);
+  color: var(--success);
+}
+
+.status-pill--fallback {
+  background: rgba(183, 103, 15, 0.12);
+  color: var(--warning);
+}
+
+.hero__panel {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 22px;
+  padding: 28px;
+  border-radius: 28px;
+}
+
+.hero__panel h2 {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  line-height: 1.05;
+}
+
+.hero__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin: 0;
+}
+
+.hero__stats div {
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+
+.hero__stats dt {
+  margin-bottom: 6px;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero__stats dd {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.section-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 26px;
+}
+
+.section-strip__item {
+  min-height: 180px;
+  padding: 22px;
+  border-radius: 24px;
+}
+
+.section-strip__item h2 {
+  margin: 0 0 10px;
+  font-size: 1.15rem;
+}
+
+.feed-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 0.95fr) minmax(260px, 0.8fr);
+  gap: 18px;
+  margin-bottom: 26px;
+}
+
+.feature-story {
+  padding: 28px;
+  border-radius: 30px;
+}
+
+.feature-story__title {
+  margin-top: 8px;
+  margin-bottom: 16px;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  line-height: 1.03;
+}
+
+.feature-story__meta,
+.story-card__meta,
+.signal-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+}
+
+.feature-story__lede {
+  margin: 0 0 22px;
+  font-size: 1rem;
+  color: var(--text-secondary);
+}
+
+.feature-story__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 14px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+}
+
+.feature-story__signal {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.feature-story__tag {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 10px 14px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.story-column {
+  display: grid;
+  gap: 18px;
+}
+
+.story-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 220px;
+  padding: 24px;
+  border-radius: 24px;
+}
+
+.story-card h3,
+.signal-card h3 {
+  margin: 0 0 10px;
+  font-size: 1.3rem;
+  line-height: 1.15;
+}
+
+.briefing-card {
+  padding: 24px;
+  border-radius: 24px;
+}
+
+.briefing-card__list {
+  margin: 18px 0 0;
+  padding-left: 18px;
+  color: var(--text-secondary);
+}
+
+.briefing-card__list li + li {
+  margin-top: 12px;
+}
+
+.signal-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.signal-card {
+  padding: 22px;
+  border-radius: 24px;
+}
+
+@media (max-width: 1040px) {
+  .hero,
+  .feed-layout,
+  .signal-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .section-strip {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .home-page {
+    width: min(100vw - 20px, 1200px);
+    padding-top: 20px;
+  }
+
+  .masthead {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: 28px;
+  }
+
+  .hero__copy,
+  .hero__panel,
+  .feature-story,
+  .story-card,
+  .briefing-card,
+  .signal-card,
+  .section-strip__item {
+    padding: 22px;
+    border-radius: 22px;
+  }
+
+  .hero__title {
+    max-width: none;
+  }
+
+  .hero__stats {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-story__footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,9 +1,11 @@
+import "./globals.css";
+
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
 export const metadata: Metadata = {
-  title: "MoaDev",
-  description: "Developer lounge for technology news and open-source pull requests.",
+  title: "MoaDev Journal",
+  description: "Editorial developer briefing for technology signals, pull requests, and follow-up actions.",
 };
 
 type RootLayoutProps = {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,20 +1,165 @@
 import { getHomeContent } from "../lib/get-home-content";
+import { getHomeFeed, type HomeFeedItem } from "../lib/get-home-feed";
 
-export default function HomePage() {
+const briefingNotes = [
+  "Lead with product and platform stories that change developer behavior, not just launch volume.",
+  "Keep pull-request coverage focused on repositories with active maintainer attention.",
+  "Always leave the reader with a next action: review, watch, contribute, or operational follow-up.",
+];
+
+export default async function HomePage() {
   const sections = getHomeContent();
+  const feed = await getHomeFeed();
+  const [leadStory, ...secondaryStories] = feed.items;
 
   return (
-    <main>
-      <h1>MoaDev</h1>
-      <p>One place for high-signal technology news, open-source pull requests, and follow-up actions.</p>
-      <ul>
+    <main className="home-page">
+      <header className="masthead">
+        <div className="masthead__brand">
+          <span className="masthead__brand-mark">M</span>
+          <span>MoaDev Journal</span>
+        </div>
+        <div className="masthead__meta">Issue #6 web home, built for live API briefing and quiet review.</div>
+      </header>
+
+      <section className="hero">
+        <div className="hero__copy">
+          <p className="eyebrow">Editorial developer feed</p>
+          <h1 className="hero__title">Read the software week before it gets noisy.</h1>
+          <p className="hero__summary">
+            Inspired by the editorial pacing of Stripe&apos;s blog, this home surface turns the MoaDev feed into
+            a calm briefing room for launches, open-source motion, and next-step execution.
+          </p>
+          <div className="hero__status-row">
+            <span className={`status-pill status-pill--${feed.status}`}>
+              {feed.status === "live" ? "Live API feed" : "Preview mode"}
+            </span>
+            <span>{feed.message}</span>
+          </div>
+        </div>
+
+        <aside className="hero__panel">
+          <div>
+            <p className="card-eyebrow">This edition</p>
+            <h2>{leadStory.title}</h2>
+            <p>{getStorySummary(leadStory)}</p>
+          </div>
+          <dl className="hero__stats">
+            <div>
+              <dt>Lead source</dt>
+              <dd>{formatSource(leadStory.source)}</dd>
+            </div>
+            <div>
+              <dt>Feed mode</dt>
+              <dd>{feed.status === "live" ? "Connected" : "Preview"}</dd>
+            </div>
+            <div>
+              <dt>Total stories</dt>
+              <dd>{feed.total}</dd>
+            </div>
+            <div>
+              <dt>Coverage</dt>
+              <dd>{formatKind(leadStory.kind)}</dd>
+            </div>
+          </dl>
+        </aside>
+      </section>
+
+      <section className="section-strip" aria-label="Coverage areas">
         {sections.map((section) => (
-          <li key={section.id}>
-            <strong>{section.title}</strong>
+          <article className="section-strip__item" key={section.id}>
+            <p className="section-strip__id">{section.id}</p>
+            <h2>{section.title}</h2>
             <p>{section.description}</p>
-          </li>
+          </article>
         ))}
-      </ul>
+      </section>
+
+      <section className="feed-layout" aria-label="Featured feed stories">
+        <article className="feature-story">
+          <p className="card-eyebrow">Featured signal</p>
+          <div className="feature-story__meta">
+            <span>{formatKind(leadStory.kind)}</span>
+            <span>{formatSource(leadStory.source)}</span>
+          </div>
+          <h2 className="feature-story__title">{leadStory.title}</h2>
+          <p className="feature-story__lede">{getStorySummary(leadStory)}</p>
+          <div className="feature-story__footer">
+            <span className="feature-story__signal">Built to connect directly to `/api/v1/feeds`.</span>
+            <span className="feature-story__tag">MoaDev briefing</span>
+          </div>
+        </article>
+
+        <div className="story-column">
+          {secondaryStories.map((story) => (
+            <article className="story-card" key={story.id}>
+              <div>
+                <p className="card-eyebrow">{formatKind(story.kind)}</p>
+                <h3>{story.title}</h3>
+                <p>{getStorySummary(story)}</p>
+              </div>
+              <div className="story-card__meta">
+                <span>{formatSource(story.source)}</span>
+                <span>{story.id}</span>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <aside className="briefing-card">
+          <p className="briefing-card__eyebrow">Desk notes</p>
+          <p>
+            The page is intentionally resilient: when the FastAPI service is not reachable, the layout stays intact
+            and swaps to preview stories instead of collapsing.
+          </p>
+          <ul className="briefing-card__list">
+            {briefingNotes.map((note) => (
+              <li key={note}>{note}</li>
+            ))}
+          </ul>
+        </aside>
+      </section>
+
+      <section className="signal-grid" aria-label="Signal cards">
+        {feed.items.map((story) => (
+          <article className="signal-card" key={`${story.id}-signal`}>
+            <p className="signal-card__eyebrow">{formatKind(story.kind)}</p>
+            <h3>{story.title}</h3>
+            <p>{getSignalDescription(story)}</p>
+            <div className="signal-card__meta">
+              <span>{formatSource(story.source)}</span>
+              <span>{story.id}</span>
+            </div>
+          </article>
+        ))}
+      </section>
     </main>
   );
+}
+
+function formatKind(kind: HomeFeedItem["kind"]): string {
+  return kind === "pull-request" ? "Open pull requests" : "Product and platform";
+}
+
+function formatSource(source: string): string {
+  return source
+    .split("-")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+function getStorySummary(story: HomeFeedItem): string {
+  if (story.kind === "pull-request") {
+    return "Open-source work with enough momentum to justify review time, watchlists, or direct contribution.";
+  }
+
+  return "High-signal coverage focused on the product, infrastructure, and tooling shifts developers should notice first.";
+}
+
+function getSignalDescription(story: HomeFeedItem): string {
+  if (story.kind === "pull-request") {
+    return "A review queue entry shaped for maintainers, contributors, and teams deciding where to spend attention.";
+  }
+
+  return "An editorial signal card for launches, ecosystem movement, and product changes that affect technical decisions.";
 }

--- a/apps/web/lib/get-home-content.ts
+++ b/apps/web/lib/get-home-content.ts
@@ -8,18 +8,18 @@ export function getHomeContent(): HomeSection[] {
   return [
     {
       id: "news",
-      title: "Global technology news",
-      description: "Curated stories that matter to developers without the surrounding noise.",
+      title: "Signal desk",
+      description: "Major product, platform, and tooling changes filtered into a quieter editorial brief.",
     },
     {
       id: "prs",
-      title: "Open-source pull request activity",
-      description: "Promising repositories and pull requests worth tracking or contributing to.",
+      title: "Review queue",
+      description: "Open-source pull requests with enough context to decide whether to watch, review, or jump in.",
     },
     {
       id: "actions",
-      title: "Action-ready follow-up",
-      description: "Structured next steps that turn insight into review, tracking, and execution.",
+      title: "Follow-up map",
+      description: "Structured next steps that turn reading into triage, comments, and execution.",
     },
   ];
 }

--- a/apps/web/lib/get-home-feed.test.ts
+++ b/apps/web/lib/get-home-feed.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getHomeFeed } from "./get-home-feed";
+
+test("returns live feed items from the FastAPI contract", async () => {
+  let requestedUrl = "";
+
+  const feed = await getHomeFeed({
+    apiBaseUrl: "https://api.moadev.test",
+    fetchFeed: async (input) => {
+      requestedUrl = input;
+
+      return {
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: "story-1",
+              kind: "news",
+              title: "Live story",
+              source: "signal-desk",
+            },
+          ],
+          meta: {
+            total: 1,
+          },
+        }),
+      };
+    },
+  });
+
+  assert.equal(requestedUrl, "https://api.moadev.test/api/v1/feeds");
+  assert.equal(feed.status, "live");
+  assert.equal(feed.total, 1);
+  assert.equal(feed.items[0]?.title, "Live story");
+});
+
+test("falls back to preview stories when the API request fails", async () => {
+  const feed = await getHomeFeed({
+    fetchFeed: async () => {
+      throw new Error("connection lost");
+    },
+  });
+
+  assert.equal(feed.status, "fallback");
+  assert.equal(feed.total, 3);
+  assert.equal(feed.items.length, 3);
+});
+
+test("falls back when the API payload shape is invalid", async () => {
+  const feed = await getHomeFeed({
+    fetchFeed: async () => ({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: "story-1",
+            kind: "unsupported-kind",
+            title: "Broken story",
+            source: "signal-desk",
+          },
+        ],
+      }),
+    }),
+  });
+
+  assert.equal(feed.status, "fallback");
+  assert.equal(feed.items[0]?.id, "preview-ai-tooling");
+});

--- a/apps/web/lib/get-home-feed.ts
+++ b/apps/web/lib/get-home-feed.ts
@@ -1,0 +1,142 @@
+export type HomeFeedItem = {
+  id: string;
+  kind: "news" | "pull-request";
+  title: string;
+  source: string;
+};
+
+export type HomeFeedResult = {
+  items: HomeFeedItem[];
+  total: number;
+  status: "live" | "fallback";
+  message: string;
+};
+
+type FeedFetcherResponse = {
+  ok: boolean;
+  json: () => Promise<unknown>;
+};
+
+type FeedFetcher = (input: string) => Promise<FeedFetcherResponse>;
+
+type GetHomeFeedOptions = {
+  apiBaseUrl?: string;
+  fetchFeed?: FeedFetcher;
+};
+
+const DEFAULT_API_BASE_URL = "http://127.0.0.1:8000";
+
+const FALLBACK_ITEMS: HomeFeedItem[] = [
+  {
+    id: "preview-ai-tooling",
+    kind: "news",
+    title: "AI tooling launches developers should evaluate this week",
+    source: "preview-desk",
+  },
+  {
+    id: "preview-infra-pr",
+    kind: "pull-request",
+    title: "Infrastructure pull requests gaining real maintainer momentum",
+    source: "preview-review-queue",
+  },
+  {
+    id: "preview-release-notes",
+    kind: "news",
+    title: "Release-note changes worth turning into follow-up actions",
+    source: "preview-operator-brief",
+  },
+];
+
+export async function getHomeFeed(options: GetHomeFeedOptions = {}): Promise<HomeFeedResult> {
+  const apiBaseUrl = options.apiBaseUrl ?? process.env.MOADEV_API_BASE_URL ?? DEFAULT_API_BASE_URL;
+  const fetchFeed = options.fetchFeed ?? defaultFetchFeed;
+
+  try {
+    const response = await fetchFeed(buildFeedUrl(apiBaseUrl));
+
+    if (!response.ok) {
+      return buildFallback("Showing preview stories while the FastAPI feed is unavailable.");
+    }
+
+    const payload = await response.json();
+    const items = parseFeedItems(payload);
+    const total = readTotal(payload, items.length);
+
+    return {
+      items,
+      total,
+      status: "live",
+      message: "Connected to the live FastAPI feed.",
+    };
+  } catch {
+    return buildFallback("Showing preview stories while the FastAPI feed is unavailable.");
+  }
+}
+
+async function defaultFetchFeed(input: string): Promise<FeedFetcherResponse> {
+  const response = await fetch(input, {
+    headers: {
+      accept: "application/json",
+    },
+  });
+
+  return {
+    ok: response.ok,
+    json: async () => response.json(),
+  };
+}
+
+function buildFeedUrl(apiBaseUrl: string): string {
+  return new URL("/api/v1/feeds", ensureTrailingSlash(apiBaseUrl)).toString();
+}
+
+function ensureTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function parseFeedItems(value: unknown): HomeFeedItem[] {
+  if (!isRecord(value) || !Array.isArray(value.data)) {
+    throw new Error("Feed payload must include a data array.");
+  }
+
+  if (!value.data.every(isHomeFeedItem)) {
+    throw new Error("Feed payload contained an invalid item.");
+  }
+
+  return value.data;
+}
+
+function readTotal(value: unknown, fallbackTotal: number): number {
+  if (isRecord(value) && isRecord(value.meta) && typeof value.meta.total === "number") {
+    return value.meta.total;
+  }
+
+  return fallbackTotal;
+}
+
+function buildFallback(message: string): HomeFeedResult {
+  return {
+    items: FALLBACK_ITEMS,
+    total: FALLBACK_ITEMS.length,
+    status: "fallback",
+    message,
+  };
+}
+
+function isHomeFeedItem(value: unknown): value is HomeFeedItem {
+  return (
+    isRecord(value) &&
+    isNonEmptyString(value.id) &&
+    (value.kind === "news" || value.kind === "pull-request") &&
+    isNonEmptyString(value.title) &&
+    isNonEmptyString(value.source)
+  );
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/apps/web/scripts/run-tests.mjs
+++ b/apps/web/scripts/run-tests.mjs
@@ -1,4 +1,4 @@
-import { rmSync } from "node:fs";
+import { readdirSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -10,7 +10,7 @@ const tscExecutable = join(
   ".bin",
   process.platform === "win32" ? "tsc.cmd" : "tsc",
 );
-const compiledTestFile = join(projectRoot, ".test-dist", "get-home-content.test.js");
+const compiledOutputDirectory = join(projectRoot, ".test-dist");
 
 function run(command, args) {
   return spawnSync(command, args, {
@@ -26,7 +26,11 @@ if (compileResult.status !== 0) {
   process.exit(compileResult.status ?? 1);
 }
 
-const testResult = run(process.execPath, ["--test", compiledTestFile]);
+const compiledTestFiles = readdirSync(compiledOutputDirectory)
+  .filter((fileName) => fileName.endsWith(".test.js"))
+  .map((fileName) => join(compiledOutputDirectory, fileName));
 
-rmSync(join(projectRoot, ".test-dist"), { force: true, recursive: true });
+const testResult = run(process.execPath, ["--test", ...compiledTestFiles]);
+
+rmSync(compiledOutputDirectory, { force: true, recursive: true });
 process.exit(testResult.status ?? 1);

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,51 @@ If a section does not apply, write `None`.
 
 ---
 
+## Release: `web-home-live-feed`
+
+- Date: `2026-04-01`
+- Status: `planned`
+- Owner: `repository-maintainers`
+
+### Summary
+
+Rebuilt the web home page into an editorial, Stripe Blog-inspired briefing surface and connected it to the FastAPI curated feed with a resilient preview fallback.
+
+### User Impact
+
+- Who is affected: contributors and operators running the web app against the API service
+- What users will notice: the home page now shows a designed editorial feed instead of a plain scaffold list, and it can render live `/api/v1/feeds` content when the API is reachable
+- Expected benefits: clearer product direction, a more intentional first impression, and a usable integration point between `apps/web` and `services/api`
+
+### Migration Notes
+
+- Required upgrade steps: set `MOADEV_API_BASE_URL` when the web app needs to reach a non-local API host
+- Data or config changes: the web app now reads the FastAPI feed contract at `/api/v1/feeds`
+- Operator actions: verify the API base URL is reachable from the Next.js runtime environment
+
+### New Env Vars
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `MOADEV_API_BASE_URL` | no | `http://127.0.0.1:8000` | Base URL used by the Next.js home page when fetching the FastAPI curated feed. |
+
+### Breaking Changes
+
+- None.
+
+### Rollback Notes
+
+- Rollback trigger: the new home feed fetch or editorial layout blocks local preview or deployment expectations
+- Rollback steps: revert the new `apps/web` home page and helper files, then restore the previous static scaffold content
+- Data recovery notes: none
+
+### Known Issues
+
+- The live API currently returns a very small curated set, so the page relies on layout polish and a preview fallback more than content volume.
+- If `MOADEV_API_BASE_URL` is misconfigured, the page intentionally falls back to preview stories instead of surfacing a hard failure.
+
+---
+
 ## Release: `api-route-based-architecture`
 
 - Date: `2026-04-01`


### PR DESCRIPTION
## Summary

- Stripe Blog의 에디토리얼 톤에서 영감을 받은 홈 화면으로 재구성
- FastAPI `/api/v1/feeds`를 읽는 `getHomeFeed` helper 추가
- API 실패 시 preview stories로 fallback 되도록 구성
- 웹 테스트 러너를 복수 test 파일을 실행할 수 있게 보강
- release notes에 홈/API 연동 변경 기록

## Testing

- make bootstrap
- make verify

Closes #6
