### PR TITLE
infra: Terraform 플랫폼 계약 모듈 추가

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,50 @@ If a section does not apply, write `None`.
 
 ---
 
+## Release: `terraform-platform-contracts`
+
+- Date: `2026-04-15`
+- Status: `planned`
+- Owner: `repository-maintainers`
+
+### Summary
+
+Added a typed Terraform platform contract module and environment-root variable declarations so the checked-in multi-cloud sample tfvars are validated explicitly before broader VM and network scaffold work lands.
+
+### User Impact
+
+- Who is affected: contributors and operators working on Terraform environment roots and sample platform values
+- What users will notice: `infra/terraform/envs/dev` and `infra/terraform/envs/prod` now validate the grouped topology contract, provider-specific placement assumptions, and shared config groups instead of accepting only the old minimal application stub
+- Expected benefits: less drift between sample files and Terraform, earlier validation of multi-cloud topology assumptions, and a clearer handoff into follow-up Terraform module work
+
+### Migration Notes
+
+- Required upgrade steps: refresh any local `terraform.tfvars` copies from the updated examples before running `terraform validate`
+- Data or config changes: AWS and OCI provider blocks now include explicit placement and bastion fields in the example contract
+- Operator actions: run Terraform validation from each environment root after updating local sample copies
+
+### New Env Vars
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `None` | no | none | No new environment variables were introduced. |
+
+### Breaking Changes
+
+- Terraform environment roots now expect the grouped topology contract instead of only the old minimal application inputs.
+
+### Rollback Notes
+
+- Rollback trigger: the typed contract blocks follow-up scaffold work or cannot be validated in the current environment
+- Rollback steps: remove the platform contract module wiring and revert the environment roots to the minimal application-only inputs
+- Data recovery notes: none
+
+### Known Issues
+
+- The contract validates input shape and cross-field assumptions only; live VM, subnet, and host bootstrap resources still belong to follow-up infrastructure issues.
+
+---
+
 ## Release: `platform-topology-docs`
 
 - Date: `2026-04-15`

--- a/infra/terraform/envs/dev/main.tf
+++ b/infra/terraform/envs/dev/main.tf
@@ -2,12 +2,41 @@ terraform {
   required_version = ">= 1.5.0"
 }
 
+locals {
+  # The directory chooses the environment so stage naming stays independent from provider selection.
+  environment = "dev"
+}
+
 module "application" {
   source       = "../../modules/application"
-  environment  = "dev"
-  service_name = "moadev"
+  environment  = local.environment
+  service_name = var.service_name
+}
+
+module "platform_contract" {
+  source = "../../modules/platform_contract"
+
+  environment       = local.environment
+  service_name      = var.service_name
+  platform_topology = var.platform_topology
+  cluster_topology  = var.cluster_topology
+  domains           = var.domains
+  images            = var.images
+  namespaces        = var.namespaces
+  ingress           = var.ingress
+  scheduling        = var.scheduling
+  cicd              = var.cicd
+  monitoring        = var.monitoring
+  storage           = var.storage
+  cost_automation   = var.cost_automation
+  oci_cluster       = var.oci_cluster
+  aws_cluster       = var.aws_cluster
 }
 
 output "release_name" {
   value = module.application.release_name
+}
+
+output "platform_contract_summary" {
+  value = module.platform_contract.summary
 }

--- a/infra/terraform/envs/dev/terraform.tfvars.example
+++ b/infra/terraform/envs/dev/terraform.tfvars.example
@@ -1,4 +1,5 @@
 # Sample only. Copy to terraform.tfvars and replace with environment-specific values outside version control.
+# Environment is selected by this directory path, not by a provider-specific variable.
 
 service_name      = "moadev"
 platform_topology = "multicloud"
@@ -118,6 +119,8 @@ oci_cluster = {
   worker_ocpus       = 2
   worker_memory_gbs  = 16
   workload_placement = "availability-domain-spread"
+  worker_placement   = "private-subnets"
+  bastion_enabled    = false
   storage_class      = "oci-bv"
 }
 
@@ -140,5 +143,9 @@ aws_cluster = {
   control_plane_instance_type = "m6i.large"
   worker_instance_type        = "m6i.large"
   worker_spot_enabled         = false
+  control_plane_endpoint_access = "private"
+  control_plane_placement       = "private-subnets"
+  worker_placement              = "private-subnets"
+  bastion_enabled               = false
   storage_class               = "gp3"
 }

--- a/infra/terraform/envs/dev/variables.tf
+++ b/infra/terraform/envs/dev/variables.tf
@@ -15,79 +15,169 @@ variable "platform_topology" {
   nullable    = false
 
   validation {
-    condition     = trimspace(var.platform_topology) != ""
-    error_message = "platform_topology must be a non-empty string."
+    condition     = contains(["single-provider", "multicloud"], var.platform_topology)
+    error_message = "platform_topology must be either single-provider or multicloud."
   }
 }
 
 variable "cluster_topology" {
   description = "Shared cluster topology settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    cluster_name           = string
+    kubernetes_version     = string
+    control_plane_provider = string
+    cni_plugin             = string
+    pod_cidr               = string
+    service_cidr           = string
+    node_groups = map(object({
+      provider         = string
+      role             = string
+      desired_count    = number
+      min_count        = number
+      max_count        = number
+      scaling_strategy = string
+    }))
+  })
+  nullable = false
 }
 
 variable "domains" {
   description = "Shared domain settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    base    = string
+    web     = string
+    api     = string
+    argocd  = string
+    grafana = string
+  })
+  nullable = false
 }
 
 variable "images" {
   description = "Shared image settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    registry                  = string
+    web_repository            = string
+    api_repository            = string
+    agents_runtime_repository = string
+    tag                       = string
+  })
+  nullable = false
 }
 
 variable "namespaces" {
   description = "Shared namespace settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    app        = string
+    platform   = string
+    monitoring = string
+    cicd       = string
+  })
+  nullable = false
 }
 
 variable "ingress" {
   description = "Ingress settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    class_name             = string
+    controller_replicas    = number
+    external_dns_zone      = string
+    load_balancer_provider = string
+    load_balancer_scheme   = string
+  })
+  nullable = false
 }
 
 variable "scheduling" {
   description = "Scheduling settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    default_node_group     = string
+    profile                = string
+    topology_spread_policy = string
+  })
+  nullable = false
 }
 
 variable "cicd" {
   description = "CI/CD settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    gitops_repository          = string
+    gitops_revision            = string
+    sync_wave                  = number
+    ci_artifact_retention_days = number
+  })
+  nullable = false
 }
 
 variable "monitoring" {
   description = "Monitoring settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    prometheus_retention = string
+    loki_retention       = string
+    grafana_admin_group  = string
+    alert_route_email    = string
+  })
+  nullable = false
 }
 
 variable "storage" {
   description = "Storage settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    artifact_bucket   = string
+    backup_bucket     = string
+    snapshot_schedule = string
+  })
+  nullable = false
 }
 
 variable "cost_automation" {
   description = "Cost automation settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    cost_center              = string
+    monthly_budget_usd       = number
+    idle_scale_down_enabled  = bool
+    idle_scale_down_schedule = string
+    report_schedule          = string
+  })
+  nullable = false
 }
 
 variable "oci_cluster" {
   description = "OCI provider settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    region              = string
+    tenancy_ocid        = string
+    compartment_ocid    = string
+    vcn_ocid            = string
+    worker_subnet_ocids = list(string)
+    worker_shape        = string
+    worker_ocpus        = number
+    worker_memory_gbs   = number
+    workload_placement  = string
+    storage_class       = string
+    worker_placement    = optional(string, "private-subnets")
+    bastion_enabled     = optional(bool, false)
+  })
+  nullable = false
 }
 
 variable "aws_cluster" {
   description = "AWS provider settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    region                          = string
+    account_id                      = string
+    vpc_id                          = string
+    control_plane_subnet_ids        = list(string)
+    worker_subnet_ids               = list(string)
+    public_load_balancer_subnet_ids = list(string)
+    control_plane_instance_type     = string
+    worker_instance_type            = string
+    worker_spot_enabled             = bool
+    storage_class                   = string
+    control_plane_endpoint_access   = optional(string, "private")
+    control_plane_placement         = optional(string, "private-subnets")
+    worker_placement                = optional(string, "private-subnets")
+    bastion_enabled                 = optional(bool, false)
+  })
+  nullable = false
 }

--- a/infra/terraform/envs/dev/variables.tf
+++ b/infra/terraform/envs/dev/variables.tf
@@ -1,0 +1,93 @@
+variable "service_name" {
+  description = "Primary service name for labels and release naming."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = trimspace(var.service_name) != ""
+    error_message = "service_name must be a non-empty string."
+  }
+}
+
+variable "platform_topology" {
+  description = "High-level platform shape consumed by the shared Terraform contract."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = trimspace(var.platform_topology) != ""
+    error_message = "platform_topology must be a non-empty string."
+  }
+}
+
+variable "cluster_topology" {
+  description = "Shared cluster topology settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "domains" {
+  description = "Shared domain settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "images" {
+  description = "Shared image settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "namespaces" {
+  description = "Shared namespace settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "ingress" {
+  description = "Ingress settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "scheduling" {
+  description = "Scheduling settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "cicd" {
+  description = "CI/CD settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "monitoring" {
+  description = "Monitoring settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "storage" {
+  description = "Storage settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "cost_automation" {
+  description = "Cost automation settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "oci_cluster" {
+  description = "OCI provider settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "aws_cluster" {
+  description = "AWS provider settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}

--- a/infra/terraform/envs/prod/main.tf
+++ b/infra/terraform/envs/prod/main.tf
@@ -2,12 +2,41 @@ terraform {
   required_version = ">= 1.5.0"
 }
 
+locals {
+  # The directory chooses the environment so stage naming stays independent from provider selection.
+  environment = "prod"
+}
+
 module "application" {
   source       = "../../modules/application"
-  environment  = "prod"
-  service_name = "moadev"
+  environment  = local.environment
+  service_name = var.service_name
+}
+
+module "platform_contract" {
+  source = "../../modules/platform_contract"
+
+  environment       = local.environment
+  service_name      = var.service_name
+  platform_topology = var.platform_topology
+  cluster_topology  = var.cluster_topology
+  domains           = var.domains
+  images            = var.images
+  namespaces        = var.namespaces
+  ingress           = var.ingress
+  scheduling        = var.scheduling
+  cicd              = var.cicd
+  monitoring        = var.monitoring
+  storage           = var.storage
+  cost_automation   = var.cost_automation
+  oci_cluster       = var.oci_cluster
+  aws_cluster       = var.aws_cluster
 }
 
 output "release_name" {
   value = module.application.release_name
+}
+
+output "platform_contract_summary" {
+  value = module.platform_contract.summary
 }

--- a/infra/terraform/envs/prod/terraform.tfvars.example
+++ b/infra/terraform/envs/prod/terraform.tfvars.example
@@ -1,4 +1,5 @@
 # Sample only. Copy to terraform.tfvars and replace with environment-specific values outside version control.
+# Environment is selected by this directory path, not by a provider-specific variable.
 
 service_name      = "moadev"
 platform_topology = "multicloud"
@@ -118,6 +119,8 @@ oci_cluster = {
   worker_ocpus       = 4
   worker_memory_gbs  = 32
   workload_placement = "availability-domain-spread"
+  worker_placement   = "private-subnets"
+  bastion_enabled    = false
   storage_class      = "oci-bv"
 }
 
@@ -140,5 +143,9 @@ aws_cluster = {
   control_plane_instance_type = "m6i.xlarge"
   worker_instance_type        = "m6i.xlarge"
   worker_spot_enabled         = false
+  control_plane_endpoint_access = "private"
+  control_plane_placement       = "private-subnets"
+  worker_placement              = "private-subnets"
+  bastion_enabled               = false
   storage_class               = "gp3"
 }

--- a/infra/terraform/envs/prod/variables.tf
+++ b/infra/terraform/envs/prod/variables.tf
@@ -15,79 +15,169 @@ variable "platform_topology" {
   nullable    = false
 
   validation {
-    condition     = trimspace(var.platform_topology) != ""
-    error_message = "platform_topology must be a non-empty string."
+    condition     = contains(["single-provider", "multicloud"], var.platform_topology)
+    error_message = "platform_topology must be either single-provider or multicloud."
   }
 }
 
 variable "cluster_topology" {
   description = "Shared cluster topology settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    cluster_name           = string
+    kubernetes_version     = string
+    control_plane_provider = string
+    cni_plugin             = string
+    pod_cidr               = string
+    service_cidr           = string
+    node_groups = map(object({
+      provider         = string
+      role             = string
+      desired_count    = number
+      min_count        = number
+      max_count        = number
+      scaling_strategy = string
+    }))
+  })
+  nullable = false
 }
 
 variable "domains" {
   description = "Shared domain settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    base    = string
+    web     = string
+    api     = string
+    argocd  = string
+    grafana = string
+  })
+  nullable = false
 }
 
 variable "images" {
   description = "Shared image settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    registry                  = string
+    web_repository            = string
+    api_repository            = string
+    agents_runtime_repository = string
+    tag                       = string
+  })
+  nullable = false
 }
 
 variable "namespaces" {
   description = "Shared namespace settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    app        = string
+    platform   = string
+    monitoring = string
+    cicd       = string
+  })
+  nullable = false
 }
 
 variable "ingress" {
   description = "Ingress settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    class_name             = string
+    controller_replicas    = number
+    external_dns_zone      = string
+    load_balancer_provider = string
+    load_balancer_scheme   = string
+  })
+  nullable = false
 }
 
 variable "scheduling" {
   description = "Scheduling settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    default_node_group     = string
+    profile                = string
+    topology_spread_policy = string
+  })
+  nullable = false
 }
 
 variable "cicd" {
   description = "CI/CD settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    gitops_repository          = string
+    gitops_revision            = string
+    sync_wave                  = number
+    ci_artifact_retention_days = number
+  })
+  nullable = false
 }
 
 variable "monitoring" {
   description = "Monitoring settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    prometheus_retention = string
+    loki_retention       = string
+    grafana_admin_group  = string
+    alert_route_email    = string
+  })
+  nullable = false
 }
 
 variable "storage" {
   description = "Storage settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    artifact_bucket   = string
+    backup_bucket     = string
+    snapshot_schedule = string
+  })
+  nullable = false
 }
 
 variable "cost_automation" {
   description = "Cost automation settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    cost_center              = string
+    monthly_budget_usd       = number
+    idle_scale_down_enabled  = bool
+    idle_scale_down_schedule = string
+    report_schedule          = string
+  })
+  nullable = false
 }
 
 variable "oci_cluster" {
   description = "OCI provider settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    region              = string
+    tenancy_ocid        = string
+    compartment_ocid    = string
+    vcn_ocid            = string
+    worker_subnet_ocids = list(string)
+    worker_shape        = string
+    worker_ocpus        = number
+    worker_memory_gbs   = number
+    workload_placement  = string
+    storage_class       = string
+    worker_placement    = optional(string, "private-subnets")
+    bastion_enabled     = optional(bool, false)
+  })
+  nullable = false
 }
 
 variable "aws_cluster" {
   description = "AWS provider settings forwarded to the platform contract module."
-  type        = any
-  nullable    = false
+  type = object({
+    region                          = string
+    account_id                      = string
+    vpc_id                          = string
+    control_plane_subnet_ids        = list(string)
+    worker_subnet_ids               = list(string)
+    public_load_balancer_subnet_ids = list(string)
+    control_plane_instance_type     = string
+    worker_instance_type            = string
+    worker_spot_enabled             = bool
+    storage_class                   = string
+    control_plane_endpoint_access   = optional(string, "private")
+    control_plane_placement         = optional(string, "private-subnets")
+    worker_placement                = optional(string, "private-subnets")
+    bastion_enabled                 = optional(bool, false)
+  })
+  nullable = false
 }

--- a/infra/terraform/envs/prod/variables.tf
+++ b/infra/terraform/envs/prod/variables.tf
@@ -1,0 +1,93 @@
+variable "service_name" {
+  description = "Primary service name for labels and release naming."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = trimspace(var.service_name) != ""
+    error_message = "service_name must be a non-empty string."
+  }
+}
+
+variable "platform_topology" {
+  description = "High-level platform shape consumed by the shared Terraform contract."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = trimspace(var.platform_topology) != ""
+    error_message = "platform_topology must be a non-empty string."
+  }
+}
+
+variable "cluster_topology" {
+  description = "Shared cluster topology settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "domains" {
+  description = "Shared domain settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "images" {
+  description = "Shared image settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "namespaces" {
+  description = "Shared namespace settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "ingress" {
+  description = "Ingress settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "scheduling" {
+  description = "Scheduling settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "cicd" {
+  description = "CI/CD settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "monitoring" {
+  description = "Monitoring settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "storage" {
+  description = "Storage settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "cost_automation" {
+  description = "Cost automation settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "oci_cluster" {
+  description = "OCI provider settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}
+
+variable "aws_cluster" {
+  description = "AWS provider settings forwarded to the platform contract module."
+  type        = any
+  nullable    = false
+}

--- a/infra/terraform/modules/platform_contract/main.tf
+++ b/infra/terraform/modules/platform_contract/main.tf
@@ -1,0 +1,53 @@
+locals {
+  providers_in_use = sort(distinct([
+    for node_group in values(var.cluster_topology.node_groups) :
+    node_group.provider
+  ]))
+
+  control_plane_node_groups = {
+    for name, node_group in var.cluster_topology.node_groups :
+    name => node_group if node_group.role == "control-plane"
+  }
+
+  worker_node_groups = {
+    for name, node_group in var.cluster_topology.node_groups :
+    name => node_group if node_group.role == "worker"
+  }
+}
+
+check "control_plane_provider_has_control_plane_node_group" {
+  assert {
+    condition = length([
+      for name, node_group in var.cluster_topology.node_groups :
+      name if node_group.provider == var.cluster_topology.control_plane_provider && node_group.role == "control-plane"
+    ]) > 0
+    error_message = "cluster_topology.control_plane_provider must match at least one control-plane node group."
+  }
+}
+
+check "platform_topology_matches_node_group_providers" {
+  assert {
+    condition = (
+      (var.platform_topology == "multicloud" && length(local.providers_in_use) >= 2) ||
+      (var.platform_topology == "single-provider" && length(local.providers_in_use) == 1)
+    )
+    error_message = "platform_topology must match the number of providers represented by cluster_topology.node_groups."
+  }
+}
+
+check "default_node_group_exists_and_is_worker" {
+  assert {
+    condition = (
+      contains(keys(var.cluster_topology.node_groups), var.scheduling.default_node_group) &&
+      var.cluster_topology.node_groups[var.scheduling.default_node_group].role == "worker"
+    )
+    error_message = "scheduling.default_node_group must exist in cluster_topology.node_groups and reference a worker node group."
+  }
+}
+
+check "load_balancer_provider_is_declared" {
+  assert {
+    condition     = contains(local.providers_in_use, var.ingress.load_balancer_provider)
+    error_message = "ingress.load_balancer_provider must match a provider that appears in cluster_topology.node_groups."
+  }
+}

--- a/infra/terraform/modules/platform_contract/outputs.tf
+++ b/infra/terraform/modules/platform_contract/outputs.tf
@@ -1,0 +1,32 @@
+output "summary" {
+  description = "Safe summary of the validated platform contract."
+  value = {
+    environment            = var.environment
+    service_name           = var.service_name
+    platform_topology      = var.platform_topology
+    cluster_name           = var.cluster_topology.cluster_name
+    kubernetes_version     = var.cluster_topology.kubernetes_version
+    control_plane_provider = var.cluster_topology.control_plane_provider
+    control_plane_groups   = sort(keys(local.control_plane_node_groups))
+    worker_groups          = sort(keys(local.worker_node_groups))
+    default_node_group     = var.scheduling.default_node_group
+    load_balancer_provider = var.ingress.load_balancer_provider
+    providers_in_use       = local.providers_in_use
+    provider_regions = {
+      aws = var.aws_cluster.region
+      oci = var.oci_cluster.region
+    }
+    provider_placement = {
+      aws = {
+        control_plane_endpoint_access = var.aws_cluster.control_plane_endpoint_access
+        control_plane_placement       = var.aws_cluster.control_plane_placement
+        worker_placement              = var.aws_cluster.worker_placement
+        bastion_enabled               = var.aws_cluster.bastion_enabled
+      }
+      oci = {
+        worker_placement = var.oci_cluster.worker_placement
+        bastion_enabled  = var.oci_cluster.bastion_enabled
+      }
+    }
+  }
+}

--- a/infra/terraform/modules/platform_contract/variables.tf
+++ b/infra/terraform/modules/platform_contract/variables.tf
@@ -1,0 +1,331 @@
+variable "environment" {
+  description = "Deployment environment selected by the environment root directory."
+  type        = string
+
+  validation {
+    condition     = trimspace(var.environment) != "" && !contains(["aws", "oci"], lower(var.environment))
+    error_message = "environment must be a non-empty stage name such as dev or prod, not a provider name."
+  }
+}
+
+variable "service_name" {
+  description = "Primary service name for labels and Terraform outputs."
+  type        = string
+
+  validation {
+    condition     = trimspace(var.service_name) != ""
+    error_message = "service_name must be a non-empty string."
+  }
+}
+
+variable "platform_topology" {
+  description = "High-level platform shape."
+  type        = string
+
+  validation {
+    condition     = contains(["single-provider", "multicloud"], var.platform_topology)
+    error_message = "platform_topology must be either single-provider or multicloud."
+  }
+}
+
+variable "cluster_topology" {
+  description = "Shared cluster topology contract across providers."
+  type = object({
+    cluster_name           = string
+    kubernetes_version     = string
+    control_plane_provider = string
+    cni_plugin             = string
+    pod_cidr               = string
+    service_cidr           = string
+    node_groups = map(object({
+      provider         = string
+      role             = string
+      desired_count    = number
+      min_count        = number
+      max_count        = number
+      scaling_strategy = string
+    }))
+  })
+
+  validation {
+    condition = (
+      trimspace(var.cluster_topology.cluster_name) != "" &&
+      trimspace(var.cluster_topology.kubernetes_version) != "" &&
+      trimspace(var.cluster_topology.cni_plugin) != "" &&
+      contains(["aws", "oci"], var.cluster_topology.control_plane_provider) &&
+      can(cidrhost(var.cluster_topology.pod_cidr, 0)) &&
+      can(cidrhost(var.cluster_topology.service_cidr, 0)) &&
+      length(var.cluster_topology.node_groups) > 0 &&
+      alltrue([
+        for node_group in values(var.cluster_topology.node_groups) :
+        contains(["aws", "oci"], node_group.provider) &&
+        contains(["control-plane", "worker"], node_group.role) &&
+        trimspace(node_group.scaling_strategy) != "" &&
+        node_group.min_count >= 0 &&
+        node_group.desired_count >= node_group.min_count &&
+        node_group.max_count >= node_group.desired_count
+      ])
+    )
+    error_message = "cluster_topology must define valid CIDRs, a supported control-plane provider, and node groups with supported provider/role values and non-decreasing counts."
+  }
+}
+
+variable "domains" {
+  description = "Shared DNS and hostname contract."
+  type = object({
+    base    = string
+    web     = string
+    api     = string
+    argocd  = string
+    grafana = string
+  })
+
+  validation {
+    condition = alltrue([
+      trimspace(var.domains.base) != "",
+      trimspace(var.domains.web) != "",
+      trimspace(var.domains.api) != "",
+      trimspace(var.domains.argocd) != "",
+      trimspace(var.domains.grafana) != "",
+    ])
+    error_message = "domains values must be non-empty."
+  }
+}
+
+variable "images" {
+  description = "Image registry and repository contract."
+  type = object({
+    registry                  = string
+    web_repository            = string
+    api_repository            = string
+    agents_runtime_repository = string
+    tag                       = string
+  })
+
+  validation {
+    condition = alltrue([
+      trimspace(var.images.registry) != "",
+      trimspace(var.images.web_repository) != "",
+      trimspace(var.images.api_repository) != "",
+      trimspace(var.images.agents_runtime_repository) != "",
+      trimspace(var.images.tag) != "",
+    ])
+    error_message = "images values must be non-empty."
+  }
+}
+
+variable "namespaces" {
+  description = "Namespace ownership contract."
+  type = object({
+    app        = string
+    platform   = string
+    monitoring = string
+    cicd       = string
+  })
+
+  validation {
+    condition = alltrue([
+      trimspace(var.namespaces.app) != "",
+      trimspace(var.namespaces.platform) != "",
+      trimspace(var.namespaces.monitoring) != "",
+      trimspace(var.namespaces.cicd) != "",
+    ])
+    error_message = "namespaces values must be non-empty."
+  }
+}
+
+variable "ingress" {
+  description = "Ingress, DNS, and load-balancer contract."
+  type = object({
+    class_name             = string
+    controller_replicas    = number
+    external_dns_zone      = string
+    load_balancer_provider = string
+    load_balancer_scheme   = string
+  })
+
+  validation {
+    condition = (
+      trimspace(var.ingress.class_name) != "" &&
+      var.ingress.controller_replicas >= 1 &&
+      trimspace(var.ingress.external_dns_zone) != "" &&
+      contains(["aws", "oci"], var.ingress.load_balancer_provider) &&
+      contains(["internet-facing", "internal", "public", "private"], var.ingress.load_balancer_scheme)
+    )
+    error_message = "ingress must declare a supported provider, a supported scheme, a non-empty class_name/external_dns_zone, and controller_replicas >= 1."
+  }
+}
+
+variable "scheduling" {
+  description = "Cluster scheduling defaults."
+  type = object({
+    default_node_group     = string
+    profile                = string
+    topology_spread_policy = string
+  })
+
+  validation {
+    condition = alltrue([
+      trimspace(var.scheduling.default_node_group) != "",
+      trimspace(var.scheduling.profile) != "",
+      trimspace(var.scheduling.topology_spread_policy) != "",
+    ])
+    error_message = "scheduling values must be non-empty."
+  }
+}
+
+variable "cicd" {
+  description = "CI/CD and GitOps settings."
+  type = object({
+    gitops_repository          = string
+    gitops_revision            = string
+    sync_wave                  = number
+    ci_artifact_retention_days = number
+  })
+
+  validation {
+    condition = (
+      trimspace(var.cicd.gitops_repository) != "" &&
+      trimspace(var.cicd.gitops_revision) != "" &&
+      var.cicd.sync_wave >= 0 &&
+      var.cicd.ci_artifact_retention_days >= 1
+    )
+    error_message = "cicd must define a repository, revision, non-negative sync_wave, and artifact retention >= 1 day."
+  }
+}
+
+variable "monitoring" {
+  description = "Monitoring defaults."
+  type = object({
+    prometheus_retention = string
+    loki_retention       = string
+    grafana_admin_group  = string
+    alert_route_email    = string
+  })
+
+  validation {
+    condition = (
+      trimspace(var.monitoring.prometheus_retention) != "" &&
+      trimspace(var.monitoring.loki_retention) != "" &&
+      trimspace(var.monitoring.grafana_admin_group) != "" &&
+      can(regex(".+@.+", var.monitoring.alert_route_email))
+    )
+    error_message = "monitoring must define non-empty retention/admin values and an email-like alert_route_email."
+  }
+}
+
+variable "storage" {
+  description = "Shared storage and backup contract."
+  type = object({
+    artifact_bucket   = string
+    backup_bucket     = string
+    snapshot_schedule = string
+  })
+
+  validation {
+    condition = alltrue([
+      trimspace(var.storage.artifact_bucket) != "",
+      trimspace(var.storage.backup_bucket) != "",
+      trimspace(var.storage.snapshot_schedule) != "",
+    ])
+    error_message = "storage values must be non-empty."
+  }
+}
+
+variable "cost_automation" {
+  description = "Cost automation defaults."
+  type = object({
+    cost_center              = string
+    monthly_budget_usd       = number
+    idle_scale_down_enabled  = bool
+    idle_scale_down_schedule = string
+    report_schedule          = string
+  })
+
+  validation {
+    condition = (
+      trimspace(var.cost_automation.cost_center) != "" &&
+      var.cost_automation.monthly_budget_usd >= 0 &&
+      trimspace(var.cost_automation.idle_scale_down_schedule) != "" &&
+      trimspace(var.cost_automation.report_schedule) != ""
+    )
+    error_message = "cost_automation must define a cost center, a non-negative budget, and non-empty schedules."
+  }
+}
+
+variable "oci_cluster" {
+  description = "Provider-specific OCI cluster contract."
+  type = object({
+    region              = string
+    tenancy_ocid        = string
+    compartment_ocid    = string
+    vcn_ocid            = string
+    worker_subnet_ocids = list(string)
+    worker_shape        = string
+    worker_ocpus        = number
+    worker_memory_gbs   = number
+    workload_placement  = string
+    storage_class       = string
+    worker_placement    = optional(string, "private-subnets")
+    bastion_enabled     = optional(bool, false)
+  })
+
+  validation {
+    condition = (
+      trimspace(var.oci_cluster.region) != "" &&
+      trimspace(var.oci_cluster.tenancy_ocid) != "" &&
+      trimspace(var.oci_cluster.compartment_ocid) != "" &&
+      trimspace(var.oci_cluster.vcn_ocid) != "" &&
+      length(var.oci_cluster.worker_subnet_ocids) > 0 &&
+      alltrue([for subnet_id in var.oci_cluster.worker_subnet_ocids : trimspace(subnet_id) != ""]) &&
+      trimspace(var.oci_cluster.worker_shape) != "" &&
+      var.oci_cluster.worker_ocpus > 0 &&
+      var.oci_cluster.worker_memory_gbs > 0 &&
+      trimspace(var.oci_cluster.workload_placement) != "" &&
+      trimspace(var.oci_cluster.storage_class) != "" &&
+      contains(["private-subnets", "mixed"], var.oci_cluster.worker_placement)
+    )
+    error_message = "oci_cluster must define non-empty provider identifiers, worker subnets, sizing, storage, and a supported worker_placement value."
+  }
+}
+
+variable "aws_cluster" {
+  description = "Provider-specific AWS cluster contract."
+  type = object({
+    region                          = string
+    account_id                      = string
+    vpc_id                          = string
+    control_plane_subnet_ids        = list(string)
+    worker_subnet_ids               = list(string)
+    public_load_balancer_subnet_ids = list(string)
+    control_plane_instance_type     = string
+    worker_instance_type            = string
+    worker_spot_enabled             = bool
+    storage_class                   = string
+    control_plane_endpoint_access   = optional(string, "private")
+    control_plane_placement         = optional(string, "private-subnets")
+    worker_placement                = optional(string, "private-subnets")
+    bastion_enabled                 = optional(bool, false)
+  })
+
+  validation {
+    condition = (
+      trimspace(var.aws_cluster.region) != "" &&
+      trimspace(var.aws_cluster.account_id) != "" &&
+      trimspace(var.aws_cluster.vpc_id) != "" &&
+      length(var.aws_cluster.control_plane_subnet_ids) > 0 &&
+      alltrue([for subnet_id in var.aws_cluster.control_plane_subnet_ids : trimspace(subnet_id) != ""]) &&
+      length(var.aws_cluster.worker_subnet_ids) > 0 &&
+      alltrue([for subnet_id in var.aws_cluster.worker_subnet_ids : trimspace(subnet_id) != ""]) &&
+      length(var.aws_cluster.public_load_balancer_subnet_ids) > 0 &&
+      alltrue([for subnet_id in var.aws_cluster.public_load_balancer_subnet_ids : trimspace(subnet_id) != ""]) &&
+      trimspace(var.aws_cluster.control_plane_instance_type) != "" &&
+      trimspace(var.aws_cluster.worker_instance_type) != "" &&
+      trimspace(var.aws_cluster.storage_class) != "" &&
+      contains(["private", "public"], var.aws_cluster.control_plane_endpoint_access) &&
+      contains(["private-subnets", "public-subnets", "mixed"], var.aws_cluster.control_plane_placement) &&
+      contains(["private-subnets", "public-subnets", "mixed"], var.aws_cluster.worker_placement)
+    )
+    error_message = "aws_cluster must define non-empty provider identifiers, subnet groups, instance types, storage, and supported placement/access values."
+  }
+}


### PR DESCRIPTION
## 요약
- 멀티클라우드 플랫폼 샘플 입력을 검증하는 공용 Terraform `platform_contract` 모듈을 추가했습니다.
- `infra/terraform/envs/dev` 와 `infra/terraform/envs/prod` 가 기존 `application` 모듈과 함께 새 계약 모듈을 소비하도록 연결했습니다.
- 샘플 `terraform.tfvars.example` 에 placement 및 bastion 필드를 명시적으로 추가했고, 운영자 관점 변경사항을 릴리스 노트에 기록했습니다.

## 상세 변경
- 공통 입력 계약에 `platform_topology`, `cluster_topology`, `domains`, `images`, `namespaces`, `ingress`, `scheduling`, `cicd`, `monitoring`, `storage`, `cost_automation` 을 typed object 로 선언했습니다.
- AWS/OCI provider 전용 입력 계약에 subnet, instance sizing, storage, placement, bastion 가정을 placeholder-safe 형태로 선언했습니다.
- control plane provider 일치 여부, `platform_topology` 와 실제 provider 수 일치 여부, 기본 worker node group 유효성, load balancer provider 유효성을 cross-field check 로 검증합니다.
- `dev` 와 `prod` 환경 선택은 provider 값이 아니라 디렉터리 경로로 고정되도록 했습니다.

## 검증
- `terraform fmt -check -recursive`
- `cd infra/terraform/envs/dev && terraform init -backend=false && terraform validate`
- `cd infra/terraform/envs/prod && terraform init -backend=false && terraform validate`
- `git diff --check`
- `make verify`

Closes #26
