### PR TITLE
[Task][P1][Infra] Add Helm chart scaffold for moadev

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,51 @@ If a section does not apply, write `None`.
 
 ---
 
+## Release: `helm-release-boundaries-scaffold`
+
+- Date: `2026-05-04`
+- Status: `planned`
+- Owner: `repository-maintainers`
+
+### Summary
+
+Added the first `platform/helm/moadev` chart scaffold with explicit release boundaries for `web`, `api`, and `agents-runtime`, plus values layering for OCI, AWS dev, and AWS prod overrides.
+
+### User Impact
+
+- Who is affected: contributors and operators preparing the first Kubernetes deployment baseline
+- What users will notice: the repository now includes a concrete Helm chart structure, provider/environment override files, and a consistent contract for image coordinates, ingress hosts, and workload-level environment wiring
+- Expected benefits: smaller follow-up diffs for issue `#16`, a clearer handoff from Terraform contract fields into chart values, and less ambiguity around which Kubernetes objects belong to each application workload
+
+### Migration Notes
+
+- Required upgrade steps: provide Kubernetes Secrets for application runtime configuration before deploying the chart into a real cluster
+- Data or config changes: Helm values now assume existing secret references for application secrets instead of embedding secret values in tracked files
+- Operator actions: map `DATABASE_URL`, `MOADEV_INTERNAL_AUTH_SECRET`, and OAuth provider credentials into cluster secrets, then choose the appropriate override file for OCI, AWS dev, or AWS prod rendering
+
+### New Env Vars
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `None` | no | none | No new process environment variables were introduced; the new chart references existing application env contracts through Kubernetes Secret keys. |
+
+### Breaking Changes
+
+- None for local app execution. The new chart establishes a Kubernetes deployment contract but does not change the existing root development commands.
+
+### Rollback Notes
+
+- Rollback trigger: the initial chart boundaries prove too opinionated for follow-up Helm or GitOps work
+- Rollback steps: remove `platform/helm/moadev` and revert the release-note entry so the repository returns to Terraform-only platform scaffolding
+- Data recovery notes: none
+
+### Known Issues
+
+- The chart intentionally stops short of Argo CD wiring, Kubespray inventory generation, NetworkPolicy resources, and stateful PostgreSQL or Redis deployment logic.
+- Workload secrets are referenced by name and key only; secret creation and rotation remain follow-up operator concerns.
+
+---
+
 ## Release: `terraform-foundation-security-boundaries`
 
 - Date: `2026-05-03`

--- a/platform/helm/moadev/Chart.yaml
+++ b/platform/helm/moadev/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: moadev
+description: Helm chart for MoaDev web, API, and agents runtime workloads.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/platform/helm/moadev/templates/_helpers.tpl
+++ b/platform/helm/moadev/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{- define "moadev.name" -}}
+{{- default .Chart.Name .Values.global.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "moadev.fullname" -}}
+{{- if .Values.global.fullnameOverride -}}
+{{- .Values.global.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "moadev.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moadev.componentFullname" -}}
+{{- printf "%s-%s" (include "moadev.fullname" .root) .component | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "moadev.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "moadev.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{- define "moadev.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .root.Chart.Name (.root.Chart.Version | replace "+" "_") }}
+{{ include "moadev.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+{{- $globalLabels := .root.Values.global.labels | default dict -}}
+{{- $valuesKey := .valuesKey | default .component -}}
+{{- $componentValues := get .root.Values $valuesKey | default dict -}}
+{{- $componentLabels := $componentValues.labels | default dict -}}
+{{- $labels := merge (deepCopy $globalLabels) $componentLabels -}}
+{{- range $key := keys $labels | sortAlpha }}
+{{ $key }}: {{ index $labels $key | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "moadev.image" -}}
+{{- $registry := .componentValues.image.registry | default .root.Values.global.imageRegistry -}}
+{{- $tag := .componentValues.image.tag | default .root.Values.global.imageTag -}}
+{{- printf "%s/%s:%s" $registry .componentValues.image.repository $tag -}}
+{{- end -}}
+
+{{- define "moadev.secretName" -}}
+{{- if .componentValues.existingSecretName -}}
+{{- .componentValues.existingSecretName -}}
+{{- else -}}
+{{- include "moadev.componentFullname" (dict "root" .root "component" .component) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moadev.renderEnv" -}}
+{{- $component := .componentValues -}}
+{{- $excludeKeys := .excludeKeys | default (list) -}}
+{{- if $component.env }}
+{{- range $name := keys $component.env | sortAlpha }}
+{{- if not (has $name $excludeKeys) }}
+- name: {{ $name }}
+  value: {{ index $component.env $name | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $component.secretEnv }}
+{{- $secretName := include "moadev.secretName" . -}}
+{{- range $name := keys $component.secretEnv | sortAlpha }}
+- name: {{ $name }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secretName }}
+      key: {{ index $component.secretEnv $name }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/platform/helm/moadev/templates/agents-runtime-deployment.yaml
+++ b/platform/helm/moadev/templates/agents-runtime-deployment.yaml
@@ -1,0 +1,55 @@
+{{- $component := .Values.agentsRuntime -}}
+{{- if $component.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "moadev.componentFullname" (dict "root" . "component" "agents-runtime") }}
+  labels:
+    {{- include "moadev.labels" (dict "root" . "component" "agents-runtime" "valuesKey" "agentsRuntime") | nindent 4 }}
+spec:
+  replicas: {{ $component.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "moadev.selectorLabels" (dict "root" . "component" "agents-runtime") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "moadev.selectorLabels" (dict "root" . "component" "agents-runtime") | nindent 8 }}
+      {{- $annotations := merge (deepCopy .Values.global.podAnnotations) ($component.podAnnotations | default dict) }}
+      {{- if $annotations }}
+      annotations:
+        {{- toYaml $annotations | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml $component.podSecurityContext | nindent 8 }}
+      containers:
+        - name: agents-runtime
+          image: {{ include "moadev.image" (dict "root" . "componentValues" $component) }}
+          imagePullPolicy: {{ $component.image.pullPolicy }}
+          env:
+            {{- include "moadev.renderEnv" (dict "root" . "component" "agents-runtime" "componentValues" $component) | nindent 12 }}
+          securityContext:
+            {{- toYaml $component.containerSecurityContext | nindent 12 }}
+          resources:
+            {{- toYaml $component.resources | nindent 12 }}
+      {{- $nodeSelector := default .Values.global.nodeSelector $component.nodeSelector }}
+      {{- if $nodeSelector }}
+      nodeSelector:
+        {{- toYaml $nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- $affinity := default .Values.global.affinity $component.affinity }}
+      {{- if $affinity }}
+      affinity:
+        {{- toYaml $affinity | nindent 8 }}
+      {{- end }}
+      {{- $tolerations := default .Values.global.tolerations $component.tolerations }}
+      {{- if $tolerations }}
+      tolerations:
+        {{- toYaml $tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/platform/helm/moadev/templates/api-deployment.yaml
+++ b/platform/helm/moadev/templates/api-deployment.yaml
@@ -1,0 +1,73 @@
+{{- $component := .Values.api -}}
+{{- if $component.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "moadev.componentFullname" (dict "root" . "component" "api") }}
+  labels:
+    {{- include "moadev.labels" (dict "root" . "component" "api") | nindent 4 }}
+spec:
+  replicas: {{ $component.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "moadev.selectorLabels" (dict "root" . "component" "api") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "moadev.selectorLabels" (dict "root" . "component" "api") | nindent 8 }}
+      {{- $annotations := merge (deepCopy .Values.global.podAnnotations) ($component.podAnnotations | default dict) }}
+      {{- if $annotations }}
+      annotations:
+        {{- toYaml $annotations | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml $component.podSecurityContext | nindent 8 }}
+      containers:
+        - name: api
+          image: {{ include "moadev.image" (dict "root" . "componentValues" $component) }}
+          imagePullPolicy: {{ $component.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $component.containerPort }}
+              protocol: TCP
+          env:
+            {{- include "moadev.renderEnv" (dict "root" . "component" "api" "componentValues" $component) | nindent 12 }}
+          securityContext:
+            {{- toYaml $component.containerSecurityContext | nindent 12 }}
+          resources:
+            {{- toYaml $component.resources | nindent 12 }}
+          {{- if $component.probes.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ $component.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ $component.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ $component.probes.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ $component.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ $component.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ $component.probes.liveness.periodSeconds }}
+          {{- end }}
+      {{- $nodeSelector := default .Values.global.nodeSelector $component.nodeSelector }}
+      {{- if $nodeSelector }}
+      nodeSelector:
+        {{- toYaml $nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- $affinity := default .Values.global.affinity $component.affinity }}
+      {{- if $affinity }}
+      affinity:
+        {{- toYaml $affinity | nindent 8 }}
+      {{- end }}
+      {{- $tolerations := default .Values.global.tolerations $component.tolerations }}
+      {{- if $tolerations }}
+      tolerations:
+        {{- toYaml $tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/platform/helm/moadev/templates/api-ingress.yaml
+++ b/platform/helm/moadev/templates/api-ingress.yaml
@@ -1,0 +1,31 @@
+{{- $component := .Values.api -}}
+{{- if and $component.enabled $component.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "moadev.componentFullname" (dict "root" . "component" "api") }}
+  labels:
+    {{- include "moadev.labels" (dict "root" . "component" "api") | nindent 4 }}
+  {{- $annotations := merge (deepCopy .Values.global.ingress.annotations) ($component.ingress.annotations | default dict) }}
+  {{- if $annotations }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  rules:
+    - host: {{ $component.ingress.host }}
+      http:
+        paths:
+          - path: {{ $component.ingress.path }}
+            pathType: {{ $component.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "moadev.componentFullname" (dict "root" . "component" "api") }}
+                port:
+                  number: {{ $component.service.port }}
+  {{- if $component.ingress.tls }}
+  tls:
+    {{- toYaml $component.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/platform/helm/moadev/templates/api-service.yaml
+++ b/platform/helm/moadev/templates/api-service.yaml
@@ -1,0 +1,18 @@
+{{- $component := .Values.api -}}
+{{- if $component.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "moadev.componentFullname" (dict "root" . "component" "api") }}
+  labels:
+    {{- include "moadev.labels" (dict "root" . "component" "api") | nindent 4 }}
+spec:
+  type: {{ $component.service.type }}
+  selector:
+    {{- include "moadev.selectorLabels" (dict "root" . "component" "api") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ $component.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/platform/helm/moadev/templates/web-deployment.yaml
+++ b/platform/helm/moadev/templates/web-deployment.yaml
@@ -1,0 +1,76 @@
+{{- $component := .Values.web -}}
+{{- if $component.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "moadev.componentFullname" (dict "root" . "component" "web") }}
+  labels:
+    {{- include "moadev.labels" (dict "root" . "component" "web") | nindent 4 }}
+spec:
+  replicas: {{ $component.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "moadev.selectorLabels" (dict "root" . "component" "web") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "moadev.selectorLabels" (dict "root" . "component" "web") | nindent 8 }}
+      {{- $annotations := merge (deepCopy .Values.global.podAnnotations) ($component.podAnnotations | default dict) }}
+      {{- if $annotations }}
+      annotations:
+        {{- toYaml $annotations | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml $component.podSecurityContext | nindent 8 }}
+      containers:
+        - name: web
+          image: {{ include "moadev.image" (dict "root" . "componentValues" $component) }}
+          imagePullPolicy: {{ $component.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $component.containerPort }}
+              protocol: TCP
+          {{- $apiBaseURL := get $component.env "MOADEV_API_BASE_URL" | default (printf "http://%s:%v" (include "moadev.componentFullname" (dict "root" . "component" "api")) .Values.api.service.port) }}
+          env:
+            - name: MOADEV_API_BASE_URL
+              value: {{ $apiBaseURL | quote }}
+            {{- include "moadev.renderEnv" (dict "root" . "component" "web" "componentValues" $component "excludeKeys" (list "MOADEV_API_BASE_URL")) | nindent 12 }}
+          securityContext:
+            {{- toYaml $component.containerSecurityContext | nindent 12 }}
+          resources:
+            {{- toYaml $component.resources | nindent 12 }}
+          {{- if $component.probes.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ $component.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ $component.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ $component.probes.readiness.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ $component.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ $component.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ $component.probes.liveness.periodSeconds }}
+          {{- end }}
+      {{- $nodeSelector := default .Values.global.nodeSelector $component.nodeSelector }}
+      {{- if $nodeSelector }}
+      nodeSelector:
+        {{- toYaml $nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- $affinity := default .Values.global.affinity $component.affinity }}
+      {{- if $affinity }}
+      affinity:
+        {{- toYaml $affinity | nindent 8 }}
+      {{- end }}
+      {{- $tolerations := default .Values.global.tolerations $component.tolerations }}
+      {{- if $tolerations }}
+      tolerations:
+        {{- toYaml $tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/platform/helm/moadev/templates/web-ingress.yaml
+++ b/platform/helm/moadev/templates/web-ingress.yaml
@@ -1,0 +1,31 @@
+{{- $component := .Values.web -}}
+{{- if and $component.enabled $component.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "moadev.componentFullname" (dict "root" . "component" "web") }}
+  labels:
+    {{- include "moadev.labels" (dict "root" . "component" "web") | nindent 4 }}
+  {{- $annotations := merge (deepCopy .Values.global.ingress.annotations) ($component.ingress.annotations | default dict) }}
+  {{- if $annotations }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  rules:
+    - host: {{ $component.ingress.host }}
+      http:
+        paths:
+          - path: {{ $component.ingress.path }}
+            pathType: {{ $component.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "moadev.componentFullname" (dict "root" . "component" "web") }}
+                port:
+                  number: {{ $component.service.port }}
+  {{- if $component.ingress.tls }}
+  tls:
+    {{- toYaml $component.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/platform/helm/moadev/templates/web-service.yaml
+++ b/platform/helm/moadev/templates/web-service.yaml
@@ -1,0 +1,18 @@
+{{- $component := .Values.web -}}
+{{- if $component.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "moadev.componentFullname" (dict "root" . "component" "web") }}
+  labels:
+    {{- include "moadev.labels" (dict "root" . "component" "web") | nindent 4 }}
+spec:
+  type: {{ $component.service.type }}
+  selector:
+    {{- include "moadev.selectorLabels" (dict "root" . "component" "web") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ $component.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/platform/helm/moadev/values-aws-dev.yaml
+++ b/platform/helm/moadev/values-aws-dev.yaml
@@ -1,0 +1,23 @@
+global:
+  labels:
+    topology.moadev.io/environment: dev
+    topology.moadev.io/provider: aws
+
+web:
+  replicaCount: 1
+  ingress:
+    host: app.dev.moadev.example.invalid
+  nodeSelector:
+    workload.moadev.io/node-group: aws-workers
+
+api:
+  replicaCount: 1
+  ingress:
+    host: api.dev.moadev.example.invalid
+  nodeSelector:
+    workload.moadev.io/node-group: aws-workers
+
+agentsRuntime:
+  replicaCount: 1
+  nodeSelector:
+    workload.moadev.io/node-group: aws-workers

--- a/platform/helm/moadev/values-aws-prod.yaml
+++ b/platform/helm/moadev/values-aws-prod.yaml
@@ -1,0 +1,23 @@
+global:
+  labels:
+    topology.moadev.io/environment: prod
+    topology.moadev.io/provider: aws
+
+web:
+  replicaCount: 2
+  ingress:
+    host: app.moadev.example.invalid
+  nodeSelector:
+    workload.moadev.io/node-group: aws-workers
+
+api:
+  replicaCount: 2
+  ingress:
+    host: api.moadev.example.invalid
+  nodeSelector:
+    workload.moadev.io/node-group: aws-workers
+
+agentsRuntime:
+  replicaCount: 2
+  nodeSelector:
+    workload.moadev.io/node-group: aws-workers

--- a/platform/helm/moadev/values-oci.yaml
+++ b/platform/helm/moadev/values-oci.yaml
@@ -1,0 +1,22 @@
+global:
+  labels:
+    topology.moadev.io/provider: oci
+
+web:
+  replicaCount: 1
+  ingress:
+    host: app.oci.moadev.example.invalid
+  nodeSelector:
+    workload.moadev.io/node-group: oci-workers
+
+api:
+  replicaCount: 1
+  ingress:
+    host: api.oci.moadev.example.invalid
+  nodeSelector:
+    workload.moadev.io/node-group: oci-workers
+
+agentsRuntime:
+  replicaCount: 1
+  nodeSelector:
+    workload.moadev.io/node-group: oci-workers

--- a/platform/helm/moadev/values.yaml
+++ b/platform/helm/moadev/values.yaml
@@ -1,0 +1,174 @@
+global:
+  nameOverride: ""
+  fullnameOverride: ""
+  imageRegistry: ghcr.io/dpwns523/moadev
+  imageTag: latest
+  imagePullSecrets: []
+  labels: {}
+  podAnnotations: {}
+  ingress:
+    className: nginx
+    annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+web:
+  enabled: true
+  replicaCount: 2
+  labels: {}
+  podAnnotations: {}
+  image:
+    repository: web
+    tag: ""
+    pullPolicy: IfNotPresent
+  containerPort: 3000
+  service:
+    type: ClusterIP
+    port: 3000
+  env:
+    NEXT_TELEMETRY_DISABLED: "1"
+  existingSecretName: ""
+  secretEnv:
+    AUTH_SECRET: AUTH_SECRET
+    AUTH_GOOGLE_ID: AUTH_GOOGLE_ID
+    AUTH_GOOGLE_SECRET: AUTH_GOOGLE_SECRET
+    AUTH_KAKAO_ID: AUTH_KAKAO_ID
+    AUTH_KAKAO_SECRET: AUTH_KAKAO_SECRET
+    AUTH_NAVER_ID: AUTH_NAVER_ID
+    AUTH_NAVER_SECRET: AUTH_NAVER_SECRET
+    MOADEV_INTERNAL_AUTH_SECRET: MOADEV_INTERNAL_AUTH_SECRET
+  ingress:
+    enabled: true
+    host: app.moadev.example.invalid
+    path: /
+    pathType: Prefix
+    annotations: {}
+    tls: []
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  podSecurityContext:
+    runAsNonRoot: true
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  probes:
+    enabled: true
+    readiness:
+      path: /login
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    liveness:
+      path: /login
+      initialDelaySeconds: 15
+      periodSeconds: 20
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+api:
+  enabled: true
+  replicaCount: 2
+  labels: {}
+  podAnnotations: {}
+  image:
+    repository: api
+    tag: ""
+    pullPolicy: IfNotPresent
+  containerPort: 8000
+  service:
+    type: ClusterIP
+    port: 8000
+  env:
+    MOADEV_INTERNAL_AUTH_MAX_AGE_SECONDS: "300"
+    PYTHONUNBUFFERED: "1"
+  existingSecretName: ""
+  secretEnv:
+    DATABASE_URL: DATABASE_URL
+    MOADEV_INTERNAL_AUTH_SECRET: MOADEV_INTERNAL_AUTH_SECRET
+  ingress:
+    enabled: true
+    host: api.moadev.example.invalid
+    path: /
+    pathType: Prefix
+    annotations: {}
+    tls: []
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  podSecurityContext:
+    runAsNonRoot: true
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  probes:
+    enabled: true
+    readiness:
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    liveness:
+      path: /health
+      initialDelaySeconds: 15
+      periodSeconds: 20
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+agentsRuntime:
+  enabled: true
+  replicaCount: 1
+  labels: {}
+  podAnnotations: {}
+  image:
+    repository: agents-runtime
+    tag: ""
+    pullPolicy: IfNotPresent
+  env:
+    AGENTS_RUNTIME_LOG_LEVEL: INFO
+    AGENTS_RUNTIME_MAX_BATCH_SIZE: "3"
+    AGENTS_RUNTIME_POLL_INTERVAL_SECONDS: "30"
+    AGENTS_RUNTIME_RUN_ONCE: "false"
+    AGENTS_RUNTIME_SIGNALS_JSON: "[]"
+  existingSecretName: ""
+  secretEnv: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  podSecurityContext:
+    runAsNonRoot: true
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+postgres:
+  enabled: false
+
+redis:
+  enabled: false
+
+monitoring:
+  serviceMonitor:
+    enabled: false


### PR DESCRIPTION
## Summary

- `platform/helm/moadev` Helm 차트 초기 스캐폴드 추가 — `web`, `api`, `agents-runtime` 3개 워크로드의 릴리즈 경계 정의
- base values + OCI·AWS dev·AWS prod 환경별 values 레이어링 구성
- 공통 헬퍼(`_helpers.tpl`)로 네이밍·라벨·이미지·시크릿·env 렌더링 재사용
- 모든 워크로드에 `runAsNonRoot`, `allowPrivilegeEscalation: false`, `capabilities.drop: ALL` 보안 컨텍스트 적용
- 시크릿 값은 추적 파일에 없음 — Kubernetes Secret name/key 참조만 사용

## Verification

```bash
helm lint platform/helm/moadev
helm template moadev-oci platform/helm/moadev -f platform/helm/moadev/values-oci.yaml
helm template moadev-aws-dev platform/helm/moadev -f platform/helm/moadev/values-aws-dev.yaml
helm template moadev-aws-prod platform/helm/moadev -f platform/helm/moadev/values-aws-prod.yaml
```

## Follow-up Note

- `platform/clusters/oci/`, `platform/clusters/aws/` 네임스페이스·ResourceQuota·LimitRange 스캐폴드는 #16 후속 작업으로 처리
- Argo CD 연결, NetworkPolicy, HPA, PodDisruptionBudget은 별도 이슈에서 처리
- 시크릿 생성·로테이션은 오퍼레이터 담당

Refs #16, #27