### PR TITLE
feat(ansible): 저비용 AWS dev 운영 스캐폴드 추가 (#15)

### DIFF
--- a/ansible/inventories/dev/aws_ec2.yml
+++ b/ansible/inventories/dev/aws_ec2.yml
@@ -3,9 +3,15 @@
 #
 # Requires the amazon.aws collection (aws_ec2 inventory plugin). Selects
 # instances by the exact tags applied in infra/terraform/modules/aws_compute_nodes
-# (KubernetesRole) and the shared_labels module (environment). Region matches
-# infra/terraform/envs/dev/terraform.tfvars.example aws_cluster.region;
-# override with -e aws_region=... if the real deployment differs.
+# (KubernetesRole) and the shared_labels module (environment). Region below
+# matches infra/terraform/envs/dev/terraform.tfvars.example aws_cluster.region.
+#
+# NOTE: this `regions:` list is static inventory-plugin config, not a
+# templated playbook var — passing -e aws_region=... does NOT change which
+# region this file queries. If the real deployment uses a different region,
+# edit the list below (it is independent of the aws_region var consumed by
+# ansible/playbooks/vars/dev.yml and the start/stop playbooks' ec2_instance
+# calls; keep both in sync manually).
 plugin: amazon.aws.aws_ec2
 regions:
   - us-west-2

--- a/ansible/inventories/dev/aws_ec2.yml
+++ b/ansible/inventories/dev/aws_ec2.yml
@@ -1,0 +1,20 @@
+---
+# Dynamic AWS EC2 inventory for the "dev" environment.
+#
+# Requires the amazon.aws collection (aws_ec2 inventory plugin). Selects
+# instances by the exact tags applied in infra/terraform/modules/aws_compute_nodes
+# (KubernetesRole) and the shared_labels module (environment). Region matches
+# infra/terraform/envs/dev/terraform.tfvars.example aws_cluster.region;
+# override with -e aws_region=... if the real deployment differs.
+plugin: amazon.aws.aws_ec2
+regions:
+  - us-west-2
+filters:
+  tag:environment: dev
+keyed_groups:
+  - key: tags.KubernetesRole
+    prefix: role
+  - key: tags.environment
+    prefix: env
+compose:
+  ansible_host: public_ip_address | default(private_ip_address)

--- a/ansible/inventories/dev/hosts.yml
+++ b/ansible/inventories/dev/hosts.yml
@@ -1,0 +1,9 @@
+---
+# Pointer/reference document only — NOT a static inventory.
+#
+# The live inventory source for this environment is aws_ec2.yml in this same
+# directory, which dynamically discovers AWS dev hosts via the amazon.aws
+# aws_ec2 inventory plugin, filtered on the "environment" and "KubernetesRole"
+# tags applied by infra/terraform/modules/aws_compute_nodes and shared_labels.
+#
+# Do not add static hosts here. See ansible/inventories/dev/aws_ec2.yml.

--- a/ansible/inventories/prod/aws_ec2.yml
+++ b/ansible/inventories/prod/aws_ec2.yml
@@ -1,0 +1,18 @@
+---
+# Dynamic AWS EC2 inventory for the "prod" environment.
+#
+# Added for structural parity with dev only (see hosts.yml in this
+# directory) — no start/stop playbook targets this environment.
+# AWS portion only; OCI prod workers are out of scope for this inventory.
+plugin: amazon.aws.aws_ec2
+regions:
+  - us-west-2
+filters:
+  tag:environment: prod
+keyed_groups:
+  - key: tags.KubernetesRole
+    prefix: role
+  - key: tags.environment
+    prefix: env
+compose:
+  ansible_host: public_ip_address | default(private_ip_address)

--- a/ansible/inventories/prod/hosts.yml
+++ b/ansible/inventories/prod/hosts.yml
@@ -1,0 +1,8 @@
+---
+# Pointer/reference document only — NOT a static inventory.
+#
+# The live inventory source for this environment is aws_ec2.yml in this same
+# directory. Kept for structural parity with the dev environment only — the
+# AWS dev start/stop playbooks never target prod (see ansible/playbooks/).
+#
+# Do not add static hosts here. See ansible/inventories/prod/aws_ec2.yml.

--- a/ansible/playbooks/start-aws-dev-cluster.yml
+++ b/ansible/playbooks/start-aws-dev-cluster.yml
@@ -10,26 +10,40 @@
 #     ansible/playbooks/start-aws-dev-cluster.yml
 #
 # Targets AWS dev workers only by default (safer default — never touches the
-# control-plane). Pass -e target_group=env_dev to include control-plane nodes.
+# control-plane). Pass -e include_control_plane=true to include it too.
+#
+# hosts: localhost is intentional, not a shortcut: Ansible skips an entire
+# play — including any guard task in it — without failing when its `hosts:`
+# pattern matches zero inventory hosts. Targeting localhost keeps this play,
+# and its "no matching instances" guard, always executing; real dynamic-
+# inventory group membership is read explicitly below via `groups`, not via
+# `hosts:`.
 - name: Start AWS dev cluster instances
-  hosts: "{{ target_group | default('role_worker:&env_dev') }}"
+  hosts: localhost
   connection: local
   gather_facts: false
+  vars_files:
+    - vars/dev.yml
   vars:
-    aws_region: us-west-2
+    include_control_plane: false
+    target_hosts: >-
+      {{
+        groups.get('env_dev', [])
+        if include_control_plane
+        else groups.get('role_worker', []) | intersect(groups.get('env_dev', []))
+      }}
   tasks:
-    - name: Fail if no matching dev instances were found  # noqa: run-once[task]
+    - name: Fail if no matching dev instances were found
       ansible.builtin.assert:
-        that: ansible_play_hosts_all | length > 0
+        that: target_hosts | length > 0
         fail_msg: >-
-          No instances matched the target group. Confirm AWS dev EC2
-          instances exist and are tagged environment=dev (see
+          No instances matched the target group (env_dev, role_worker unless
+          include_control_plane=true). Confirm AWS dev EC2 instances exist and
+          are tagged environment=dev, KubernetesRole=worker (see
           infra/terraform/modules/aws_compute_nodes).
-      run_once: true  # intentional: one aggregate API call, not per-host; strategy stays linear
 
-    - name: Start tagged AWS dev instances  # noqa: run-once[task]
+    - name: Start tagged AWS dev instances
       amazon.aws.ec2_instance:
         state: started
         region: "{{ aws_region }}"
-        instance_ids: "{{ ansible_play_hosts_all | map('extract', hostvars, 'instance_id') | list }}"
-      run_once: true  # intentional: one aggregate API call, not per-host; strategy stays linear
+        instance_ids: "{{ target_hosts | map('extract', hostvars, 'instance_id') | list }}"

--- a/ansible/playbooks/start-aws-dev-cluster.yml
+++ b/ansible/playbooks/start-aws-dev-cluster.yml
@@ -1,0 +1,35 @@
+---
+# Starts previously-stopped AWS dev EC2 instances.
+#
+# Standalone, manually-invoked. Not wired to the existing Terraform scheduler
+# skeleton (still implementation-status: skeleton-only) or any CI pipeline —
+# see Issue #15.
+#
+# Usage:
+#   ansible-playbook -i ansible/inventories/dev/aws_ec2.yml \
+#     ansible/playbooks/start-aws-dev-cluster.yml
+#
+# Targets AWS dev workers only by default (safer default — never touches the
+# control-plane). Pass -e target_group=env_dev to include control-plane nodes.
+- name: Start AWS dev cluster instances
+  hosts: "{{ target_group | default('role_worker:&env_dev') }}"
+  connection: local
+  gather_facts: false
+  vars:
+    aws_region: us-west-2
+  tasks:
+    - name: Fail if no matching dev instances were found  # noqa: run-once[task]
+      ansible.builtin.assert:
+        that: ansible_play_hosts_all | length > 0
+        fail_msg: >-
+          No instances matched the target group. Confirm AWS dev EC2
+          instances exist and are tagged environment=dev (see
+          infra/terraform/modules/aws_compute_nodes).
+      run_once: true  # intentional: one aggregate API call, not per-host; strategy stays linear
+
+    - name: Start tagged AWS dev instances  # noqa: run-once[task]
+      amazon.aws.ec2_instance:
+        state: started
+        region: "{{ aws_region }}"
+        instance_ids: "{{ ansible_play_hosts_all | map('extract', hostvars, 'instance_id') | list }}"
+      run_once: true  # intentional: one aggregate API call, not per-host; strategy stays linear

--- a/ansible/playbooks/stop-aws-dev-cluster.yml
+++ b/ansible/playbooks/stop-aws-dev-cluster.yml
@@ -11,26 +11,40 @@
 #     ansible/playbooks/stop-aws-dev-cluster.yml
 #
 # Targets AWS dev workers only by default (safer default — never touches the
-# control-plane). Pass -e target_group=env_dev to include control-plane nodes.
+# control-plane). Pass -e include_control_plane=true to include it too.
+#
+# hosts: localhost is intentional, not a shortcut: Ansible skips an entire
+# play — including any guard task in it — without failing when its `hosts:`
+# pattern matches zero inventory hosts. Targeting localhost keeps this play,
+# and its "no matching instances" guard, always executing; real dynamic-
+# inventory group membership is read explicitly below via `groups`, not via
+# `hosts:`.
 - name: Stop AWS dev cluster instances
-  hosts: "{{ target_group | default('role_worker:&env_dev') }}"
+  hosts: localhost
   connection: local
   gather_facts: false
+  vars_files:
+    - vars/dev.yml
   vars:
-    aws_region: us-west-2
+    include_control_plane: false
+    target_hosts: >-
+      {{
+        groups.get('env_dev', [])
+        if include_control_plane
+        else groups.get('role_worker', []) | intersect(groups.get('env_dev', []))
+      }}
   tasks:
-    - name: Fail if no matching dev instances were found  # noqa: run-once[task]
+    - name: Fail if no matching dev instances were found
       ansible.builtin.assert:
-        that: ansible_play_hosts_all | length > 0
+        that: target_hosts | length > 0
         fail_msg: >-
-          No instances matched the target group. Confirm AWS dev EC2
-          instances exist and are tagged environment=dev (see
+          No instances matched the target group (env_dev, role_worker unless
+          include_control_plane=true). Confirm AWS dev EC2 instances exist and
+          are tagged environment=dev, KubernetesRole=worker (see
           infra/terraform/modules/aws_compute_nodes).
-      run_once: true  # intentional: one aggregate API call, not per-host; strategy stays linear
 
-    - name: Stop tagged AWS dev instances (EBS preserved, not terminated)  # noqa: run-once[task]
+    - name: Stop tagged AWS dev instances (EBS preserved, not terminated)
       amazon.aws.ec2_instance:
         state: stopped
         region: "{{ aws_region }}"
-        instance_ids: "{{ ansible_play_hosts_all | map('extract', hostvars, 'instance_id') | list }}"
-      run_once: true  # intentional: one aggregate API call, not per-host; strategy stays linear
+        instance_ids: "{{ target_hosts | map('extract', hostvars, 'instance_id') | list }}"

--- a/ansible/playbooks/stop-aws-dev-cluster.yml
+++ b/ansible/playbooks/stop-aws-dev-cluster.yml
@@ -1,0 +1,36 @@
+---
+# Stops (not terminates) AWS dev EC2 instances for cost savings. EBS volumes
+# are preserved so instances can be restarted with start-aws-dev-cluster.yml.
+#
+# Standalone, manually-invoked. Not wired to the existing Terraform scheduler
+# skeleton (still implementation-status: skeleton-only) or any CI pipeline —
+# see Issue #15.
+#
+# Usage:
+#   ansible-playbook -i ansible/inventories/dev/aws_ec2.yml \
+#     ansible/playbooks/stop-aws-dev-cluster.yml
+#
+# Targets AWS dev workers only by default (safer default — never touches the
+# control-plane). Pass -e target_group=env_dev to include control-plane nodes.
+- name: Stop AWS dev cluster instances
+  hosts: "{{ target_group | default('role_worker:&env_dev') }}"
+  connection: local
+  gather_facts: false
+  vars:
+    aws_region: us-west-2
+  tasks:
+    - name: Fail if no matching dev instances were found  # noqa: run-once[task]
+      ansible.builtin.assert:
+        that: ansible_play_hosts_all | length > 0
+        fail_msg: >-
+          No instances matched the target group. Confirm AWS dev EC2
+          instances exist and are tagged environment=dev (see
+          infra/terraform/modules/aws_compute_nodes).
+      run_once: true  # intentional: one aggregate API call, not per-host; strategy stays linear
+
+    - name: Stop tagged AWS dev instances (EBS preserved, not terminated)  # noqa: run-once[task]
+      amazon.aws.ec2_instance:
+        state: stopped
+        region: "{{ aws_region }}"
+        instance_ids: "{{ ansible_play_hosts_all | map('extract', hostvars, 'instance_id') | list }}"
+      run_once: true  # intentional: one aggregate API call, not per-host; strategy stays linear

--- a/ansible/playbooks/vars/dev.yml
+++ b/ansible/playbooks/vars/dev.yml
@@ -1,0 +1,5 @@
+---
+# Shared vars for the AWS dev start/stop playbooks. Single source of truth
+# for aws_region so it isn't hardcoded independently in each playbook.
+# Matches infra/terraform/envs/dev/terraform.tfvars.example aws_cluster.region.
+aws_region: us-west-2

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# Common host preparation for MoaDev AWS/OCI nodes.
+# Idempotent, sample-safe: no secrets, no environment-specific values.
+- name: Ensure base packages are present
+  ansible.builtin.package:
+    name:
+      - curl
+      - ca-certificates
+    state: present
+  become: true

--- a/ansible/roles/k3s_agent/README.md
+++ b/ansible/roles/k3s_agent/README.md
@@ -1,0 +1,8 @@
+# k3s_agent (placeholder)
+
+Empty placeholder role. No functional k3s installation logic yet.
+
+Primary cluster bootstrap remains Kubespray (tracked in Issue #17, Epic #19).
+This role exists as scaffolding for a possible future lightweight/fallback
+k3s worker setup, per Issue #15's scope decisions. Do not add functional
+task logic here without revisiting that scope.

--- a/ansible/roles/k3s_server/README.md
+++ b/ansible/roles/k3s_server/README.md
@@ -1,0 +1,8 @@
+# k3s_server (placeholder)
+
+Empty placeholder role. No functional k3s installation logic yet.
+
+Primary cluster bootstrap remains Kubespray (tracked in Issue #17, Epic #19).
+This role exists as scaffolding for a possible future lightweight/fallback
+k3s control-plane setup, per Issue #15's scope decisions. Do not add
+functional task logic here without revisiting that scope.


### PR DESCRIPTION
## 요약

- `environment`/`KubernetesRole` 태그 기반 동적 dev/prod Ansible 인벤토리 추가 (`aws_ec2.yml`). `hosts.yml`은 실제 대상이 `aws_ec2.yml`임을 안내하는 설명 문서로만 유지
- 기본 호스트 준비용 `common` 롤 추가
- `k3s_server`/`k3s_agent`는 기능 로직 없는 빈 플레이스홀더 롤로 추가 (실제 클러스터 부트스트랩은 Kubespray, Issue #17에서 별도 진행)
- AWS dev 클러스터 전용 start/stop 플레이북 추가 — 기본값은 worker만 대상(`role_worker:&env_dev`)으로 control-plane은 안전하게 제외, `amazon.aws.ec2_instance`로 AWS API를 직접 호출해 인스턴스를 정지(EBS 보존, 삭제 아님)/시작
- 기존 Terraform `aws_scheduler` 스켈레톤(아직 skeleton-only)이나 CI 파이프라인과는 연결하지 않음 — 독립적으로 수동 실행되는 도구

`ooo interview` → `ooo seed`(QA 0.93 PASS)로 요구사항을 정리한 뒤, MCP 실행 엔진이 이 환경에 연결되어 있지 않아 시드의 acceptance_criteria를 기준으로 직접 구현했습니다. Issue #15 본문도 이 시드 내용에 맞춰 갱신했습니다.

## 테스트 플랜

- [x] `python3 -c "import yaml; ..."` — dev/prod `aws_ec2.yml` YAML 유효성 확인
- [x] `hosts.yml`이 `aws_ec2.yml`을 참조하는지 확인 (dev/prod 모두)
- [x] `ansible-playbook --syntax-check` — start/stop 플레이북 모두 통과
- [x] SSM 관련 참조(`community.aws.aws_ssm`, `ssm_send_command`) 없음 확인
- [x] 비밀/자격증명 패턴, `aws_scheduler`/`.github/workflows` 참조, `prod` 참조 없음 확인 (grep)
- [x] `ansible-lint ansible/` — production 프로파일 기준 0 failure, 0 warning (13개 파일)

## 관련 이슈

Closes #15 (Epic #19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)